### PR TITLE
Gnome 42 compatibility fixes/hacks

### DIFF
--- a/tiling-assistant@leleat-on-github/metadata.json
+++ b/tiling-assistant@leleat-on-github/metadata.json
@@ -3,7 +3,8 @@
   "name": "Tiling Assistant",
   "shell-version": [
     "40",
-    "41"
+    "41",
+    "42"
   ],
   "url": "https://github.com/Leleat/Tiling-Assistant",
   "uuid": "tiling-assistant@leleat-on-github",

--- a/tiling-assistant@leleat-on-github/prefs.js
+++ b/tiling-assistant@leleat-on-github/prefs.js
@@ -117,7 +117,6 @@ const PrefsWidget = GObject.registerClass({
         // Setup titlebar and size
         this.connect('realize', () => {
             const prefsDialog = this.get_root();
-            prefsDialog.set_titlebar(this._title_bar);
             prefsDialog.add_css_class('tiling-assistant');
             prefsDialog.set_default_size(550, 750);
 

--- a/tiling-assistant@leleat-on-github/src/extension/altTab.js
+++ b/tiling-assistant@leleat-on-github/src/extension/altTab.js
@@ -204,7 +204,8 @@ var AppSwitcherItem = GObject.registerClass({
                 Main.activateWindow(this.cachedWindows[0], timestamp);
             },
             // Listening to the app-stop now happens in the custom _init func
-            connect: () => {}
+            connect: () => {},
+            connectObject: () => {}
         };
 
         this.updateAppIcons();

--- a/tiling-assistant@leleat-on-github/src/extension/layoutsManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/layoutsManager.js
@@ -304,14 +304,13 @@ const LayoutSearch = GObject.registerClass({
         });
         Main.uiGroup.add_child(this);
 
-        if (!Main.pushModal(this)) {
-            // Probably someone else has a pointer grab, try again with keyboard
-            const alreadyGrabbed = Meta.ModalOptions.POINTER_ALREADY_GRABBED;
-            if (!Main.pushModal(this, { options: alreadyGrabbed })) {
-                this.destroy();
-                return;
-            }
+        let grab = Main.pushModal(this);
+        // We expect at least a keyboard grab here
+        if ((grab.get_seat_state() & Clutter.GrabState.KEYBOARD) === 0) {
+            Main.popModal(grab);
+            return false;
         }
+        this._grab = grab;
 
         this._haveModal = true;
         this._focused = -1;
@@ -361,7 +360,7 @@ const LayoutSearch = GObject.registerClass({
 
     destroy() {
         if (this._haveModal) {
-            Main.popModal(this);
+            Main.popModal(this._grab);
             this._haveModal = false;
         }
 

--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -223,15 +223,7 @@ var Handler = class TilingMoveHandler {
     }
 
     _onMoving(grabOp, window, topTileGroup, freeScreenRects) {
-        // Use the current event's coords instead of global.get_pointer
-        // to support touch...?
-        const event = Clutter.get_current_event();
-        if (!event)
-            return;
-
-        const [eventX, eventY] = grabOp === Meta.GrabOp.KEYBOARD_MOVING
-            ? global.get_pointer()
-            : event.get_coords();
+        const [eventX, eventY] = global.get_pointer();
         this._lastPointerPos = { x: eventX, y: eventY };
 
         const ctrl = Clutter.ModifierType.CONTROL_MASK;

--- a/tiling-assistant@leleat-on-github/src/extension/tileEditingMode.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tileEditingMode.js
@@ -50,14 +50,13 @@ class TileEditingMode extends St.Widget {
     }
 
     open() {
-        if (!Main.pushModal(this)) {
-            // Probably someone else has a pointer grab, try again with keyboard
-            const alreadyGrabbed = Meta.ModalOptions.POINTER_ALREADY_GRABBED;
-            if (!Main.pushModal(this, { options: alreadyGrabbed })) {
-                this.destroy();
-                return;
-            }
+        let grab = Main.pushModal(this);
+        // We expect at least a keyboard grab here
+        if ((grab.get_seat_state() & Clutter.GrabState.KEYBOARD) === 0) {
+            Main.popModal(grab);
+            return false;
         }
+        this._grab = grab;
 
         this._haveModal = true;
         this._windows = Twm.getTopTileGroup();
@@ -93,7 +92,7 @@ class TileEditingMode extends St.Widget {
 
     close() {
         if (this._haveModal) {
-            Main.popModal(this);
+            Main.popModal(this._grab);
             this._haveModal = false;
         }
 

--- a/tiling-assistant@leleat-on-github/src/extension/tilingPopup.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingPopup.js
@@ -73,12 +73,13 @@ var TilingSwitcherPopup = GObject.registerClass({
         if (!this._items.length)
             return false;
 
-        if (!Main.pushModal(this)) {
-            // Probably someone else has a pointer grab, try again with keyboard
-            const alreadyGrabbed = Meta.ModalOptions.POINTER_ALREADY_GRABBED;
-            if (!Main.pushModal(this, { options: alreadyGrabbed }))
-                return false;
+        let grab = Main.pushModal(this);
+        // We expect at least a keyboard grab here
+        if ((grab.get_seat_state() & Clutter.GrabState.KEYBOARD) === 0) {
+            Main.popModal(grab);
+            return false;
         }
+        this._grab = grab;
 
         this._haveModal = true;
 


### PR DESCRIPTION
I made some fixes and hacks to make this extension work on Gnome-shell 42.0 (Ubuntu 22.04). Fixes #144.

I don't really expect this PR to be merged because some of those fixes are just feature removal. This PR also break compatibility with old gnome-shell versions, I don't know if it's an issue. However it seems to work on my system and can maybe help maintainers to make a propre upgrade to this extension.

### Fixes

- `fadeAndDestroy()` expect a `this._grab` attribute
    - `pushModal()` now return a `grab` object instead of a boolean ([diff](https://github.com/GNOME/gnome-shell/commit/7419674bd39b0ac644b3fdb1cb5ba584f20526ee#diff-fbad094aec08ac6767eceb5dcfe9986d687c61f6d83b49b77544b0e02781d5fcL542))
    - This grab object is expected to be fed to `popModal()` ([diff](https://github.com/GNOME/gnome-shell/commit/7419674bd39b0ac644b3fdb1cb5ba584f20526ee#diff-fbad094aec08ac6767eceb5dcfe9986d687c61f6d83b49b77544b0e02781d5fcL597))
    - `super.fadeAndDestro()` use the `this._grab` attribute to call `popModal()`, so we need to define it ([source](https://github.com/GNOME/gnome-shell/blob/42.0/js/ui/switcherPopup.js#L311))
    - I fixed it by copying the update of `SwitcherPopup.show()` and applying it to  `TilingSwitcherPopup.show()`. ([source](https://github.com/GNOME/gnome-shell/blob/42.0/js/ui/switcherPopup.js#L105))
- `AppSwitcher._addIcon()` now use `appIcon.app.connectObject` instead of `appIcon.app.connect`
    - Source: https://github.com/GNOME/gnome-shell/blob/42.0/js/ui/altTab.js#L868
    - I just defined `connectObject` like `connect` was defined

### Hacks/Feature removal

- `set_titlebar()` not supported by libadwaita 
    - Source: https://gitlab.gnome.org/GNOME/libadwaita/-/blob/main/src/adw-window.c#L41
    - I just removed the call, I don't really know what that function was doing.

- All `_onMoving()` event were always ignored
   - It seems that in my case all `Clutter.get_current_event()` was always null.
   - I just removed it, maybe it will break the extension on touchscreens?
