### PR TITLE
Implement gaps to maximized windows on double-click

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/resizeHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/resizeHandler.js
@@ -266,8 +266,6 @@ var Handler = class TilingResizeHandler {
 
         const screenTopGap = Settings.getInt(Settings.SCREEN_TOP_GAP);
         const screenLeftGap = Settings.getInt(Settings.SCREEN_LEFT_GAP);
-        const screenRightGap = Settings.getInt(Settings.SCREEN_RIGHT_GAP);
-        const screenBottomGap = Settings.getInt(Settings.SCREEN_BOTTOM_GAP);
         const windowGap = Settings.getInt(Settings.WINDOW_GAP);
         const workArea = window.get_work_area_for_monitor(window.get_monitor());
 

--- a/tiling-assistant@leleat-on-github/src/extension/resizeHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/resizeHandler.js
@@ -69,8 +69,11 @@ var Handler = class TilingResizeHandler {
     }
 
     _onResizeStarted(window, grabOp) {
-        if (!window.isTiled)
+        if (!window.isTiled) {
+            if (window.tiledRect)
+                this._preGrabRects.set(window, new Rect(window.get_frame_rect()));
             return;
+        }
 
         // Use the same margin for the alignment and equality check below.
         const margin = 5;
@@ -261,7 +264,7 @@ var Handler = class TilingResizeHandler {
             this._sizeChangedId = 0;
         }
 
-        if (!window.isTiled)
+        if (!window.isTiled && !window.tiledRect)
             return;
 
         const screenTopGap = Settings.getInt(Settings.SCREEN_TOP_GAP);

--- a/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
@@ -1215,7 +1215,7 @@ var TilingWindowManager = class TilingWindowManager {
      * @param {Meta.Actor} actor 
      */
     static _onWindowSizeChange(_, actor, __, ___) {
-        // Only override maximization if maximized window gaps are enabled and if any gap is non-zero
+        // Only override maximization if maximized window gaps are enabled
         if (!Util.isMaximizedGapsEnabled())
             return;
 

--- a/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
@@ -26,7 +26,7 @@ var TilingWindowManager = class TilingWindowManager {
 
         this._wsAddedId = global.workspace_manager.connect('workspace-added', this._onWorkspaceAdded.bind(this));
         this._wsRemovedId = global.workspace_manager.connect('workspace-removed', this._onWorkspaceRemoved.bind(this));
-        this._windowSizeChange = global.window_manager.connect('size-change', this._onWindowSizeChange.bind(this));
+        this._windowSizeChangeId = global.window_manager.connect('size-change', this._onWindowSizeChange.bind(this));
     }
 
     static destroy() {
@@ -35,7 +35,7 @@ var TilingWindowManager = class TilingWindowManager {
 
         global.workspace_manager.disconnect(this._wsAddedId);
         global.workspace_manager.disconnect(this._wsRemovedId);
-        global.window_manager.disconnect(this._windowSizeChange);
+        global.window_manager.disconnect(this._windowSizeChangeId);
 
         this._tileGroups.clear();
         this._unmanagingWindows = [];
@@ -1214,12 +1214,9 @@ var TilingWindowManager = class TilingWindowManager {
      * This handles the cases where the titlebar is double-clicked, maximizing
      * the window.
      * 
-     * @param {*} _ 
      * @param {Meta.Actor} actor 
-     * @param {Meta.SizeChange} change 
-     * @param {*} __ 
      */
-    static _onWindowSizeChange(_, actor, change, __) {
+    static _onWindowSizeChange(_, actor, __, ___) {
         const window = actor.meta_window;
         const workArea = window.get_work_area_for_monitor(window.get_monitor());
         if (window.window_type === Meta.WindowType.NORMAL && this.isMaximized(window, workArea)) {

--- a/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
@@ -1220,13 +1220,19 @@ var TilingWindowManager = class TilingWindowManager {
      * @param {Meta.Actor} actor 
      */
     static _onWindowSizeChange(_, actor, __, ___) {
-        const window = actor.meta_window;
-        const workArea = window.get_work_area_for_monitor(window.get_monitor());
-        if (window.window_type === Meta.WindowType.NORMAL && this.isMaximized(window, workArea)) {
-            const workAreaRect = new Rect(workArea);
-            this.tile(window, workAreaRect, { openTilingPopup: false, skipAnim: true });
+        const screenTopGap = Settings.getInt(Settings.SCREEN_TOP_GAP);
+        const screenLeftGap = Settings.getInt(Settings.SCREEN_LEFT_GAP);
+        const screenRightGap = Settings.getInt(Settings.SCREEN_RIGHT_GAP);
+        const screenBottomGap = Settings.getInt(Settings.SCREEN_BOTTOM_GAP);
+        const maxUsesGap = (screenTopGap || screenLeftGap || screenRightGap || screenBottomGap) && Settings.getBoolean(Settings.MAXIMIZE_WITH_GAPS);
+        if (maxUsesGap) {
+            const window = actor.meta_window;
+            const workArea = window.get_work_area_for_monitor(window.get_monitor());
+            if (window.window_type === Meta.WindowType.NORMAL && this.isMaximized(window, workArea)) {
+                const workAreaRect = new Rect(workArea);
+                this.tile(window, workAreaRect, { openTilingPopup: false, skipAnim: true });
+            }
         }
-
     }
 };
 

--- a/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
@@ -1225,15 +1225,14 @@ var TilingWindowManager = class TilingWindowManager {
         const screenRightGap = Settings.getInt(Settings.SCREEN_RIGHT_GAP);
         const screenBottomGap = Settings.getInt(Settings.SCREEN_BOTTOM_GAP);
         const maxUsesGap = (screenTopGap || screenLeftGap || screenRightGap || screenBottomGap) && Settings.getBoolean(Settings.MAXIMIZE_WITH_GAPS);
-
         if (maxUsesGap) {
             const window = actor.meta_window;
             const workArea = window.get_work_area_for_monitor(window.get_monitor());
             const workAreaRect = new Rect(workArea);
-            if (window.get_maximized() === Meta.MaximizeFlags.BOTH) {
+            if (window.tiledRect && window.tiledRect.equal(workAreaRect)) {
+                this.untile(window);
+            } else if (window.get_maximized() === Meta.MaximizeFlags.BOTH) {
                 this.tile(window, workAreaRect, { openTilingPopup: false, skipAnim: true });
-            } else if (window.tiledRect && window.tiledRect.equal(workAreaRect)) {
-                global.log('minimize here!');
             }
         }
     }

--- a/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
@@ -1220,8 +1220,6 @@ var TilingWindowManager = class TilingWindowManager {
      * @param {Meta.Actor} actor 
      */
     static _onWindowSizeChange(_, actor, __, ___) {
-        if (window.window_type !== Meta.WindowType.NORMAL) return;
-
         const screenTopGap = Settings.getInt(Settings.SCREEN_TOP_GAP);
         const screenLeftGap = Settings.getInt(Settings.SCREEN_LEFT_GAP);
         const screenRightGap = Settings.getInt(Settings.SCREEN_RIGHT_GAP);

--- a/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
@@ -1227,7 +1227,7 @@ var TilingWindowManager = class TilingWindowManager {
         
         // If the window is maximized, untile it. Otherwise, tile the window to the monitor's work area
         const workAreaRect = new Rect(window.get_work_area_for_monitor(window.get_monitor()));
-        if (window.tiledRect && window.tiledRect.equal(workAreaRect)) {
+        if (window.tiledRect?.equal(workAreaRect)) {
             this.untile(window);
         } else {
             this.tile(window, workAreaRect, { openTilingPopup: false, skipAnim: true });

--- a/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
@@ -1220,17 +1220,22 @@ var TilingWindowManager = class TilingWindowManager {
      * @param {Meta.Actor} actor 
      */
     static _onWindowSizeChange(_, actor, __, ___) {
+        if (window.window_type !== Meta.WindowType.NORMAL) return;
+
         const screenTopGap = Settings.getInt(Settings.SCREEN_TOP_GAP);
         const screenLeftGap = Settings.getInt(Settings.SCREEN_LEFT_GAP);
         const screenRightGap = Settings.getInt(Settings.SCREEN_RIGHT_GAP);
         const screenBottomGap = Settings.getInt(Settings.SCREEN_BOTTOM_GAP);
         const maxUsesGap = (screenTopGap || screenLeftGap || screenRightGap || screenBottomGap) && Settings.getBoolean(Settings.MAXIMIZE_WITH_GAPS);
+
         if (maxUsesGap) {
             const window = actor.meta_window;
             const workArea = window.get_work_area_for_monitor(window.get_monitor());
-            if (window.window_type === Meta.WindowType.NORMAL && this.isMaximized(window, workArea)) {
-                const workAreaRect = new Rect(workArea);
+            const workAreaRect = new Rect(workArea);
+            if (window.get_maximized() === Meta.MaximizeFlags.BOTH) {
                 this.tile(window, workAreaRect, { openTilingPopup: false, skipAnim: true });
+            } else if (window.tiledRect && window.tiledRect.equal(workAreaRect)) {
+                global.log('minimize here!');
             }
         }
     }

--- a/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
@@ -1213,19 +1213,15 @@ var TilingWindowManager = class TilingWindowManager {
      * the window.
      * 
      * @param {Meta.Actor} actor 
+     * @param {Meta.SizeChange} change
      */
-    static _onWindowSizeChange(_, actor, __, ___) {
-        // Only override maximization if maximized window gaps are enabled
-        if (!Util.isMaximizedGapsEnabled())
+    static _onWindowSizeChange(_, actor, change, ___) {
+        // Only override maximization if the window is being maximized or if maximized window gaps are enabled
+        if (change !== Meta.SizeChange.MAXIMIZE || !Util.isMaximizedGapsEnabled())
             return;
 
-        const window = actor.meta_window;
-        
-        // Only override maximization if the window was maximized
-        if (window.get_maximized() !== Meta.MaximizeFlags.BOTH)
-            return;
-        
         // If the window is maximized, untile it. Otherwise, tile the window to the monitor's work area
+        const window = actor.meta_window;
         const workAreaRect = new Rect(window.get_work_area_for_monitor(window.get_monitor()));
         if (window.tiledRect?.equal(workAreaRect)) {
             this.untile(window);

--- a/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
@@ -26,8 +26,7 @@ var TilingWindowManager = class TilingWindowManager {
 
         this._wsAddedId = global.workspace_manager.connect('workspace-added', this._onWorkspaceAdded.bind(this));
         this._wsRemovedId = global.workspace_manager.connect('workspace-removed', this._onWorkspaceRemoved.bind(this));
-
-        this._windowSizeChange = global.window_manager.connect('size-change', this._onWindowSizeChange.bind(this))
+        this._windowSizeChange = global.window_manager.connect('size-change', this._onWindowSizeChange.bind(this));
     }
 
     static destroy() {
@@ -1222,11 +1221,10 @@ var TilingWindowManager = class TilingWindowManager {
      */
     static _onWindowSizeChange(_, actor, change, __) {
         const window = actor.meta_window;
-        if (window.window_type === Meta.WindowType.NORMAL && change === Meta.SizeChange.MAXIMIZE 
-            && window.get_maximized() === Meta.MaximizeFlags.BOTH) {
-            const wA = window.get_work_area_for_monitor(window.get_monitor());
-            const workArea = new Rect(wA);
-            this.tile(window, workArea, { openTilingPopup: false, skipAnim: true });
+        const workArea = window.get_work_area_for_monitor(window.get_monitor());
+        if (window.window_type === Meta.WindowType.NORMAL && this.isMaximized(window, workArea)) {
+            const workAreaRect = new Rect(workArea);
+            this.tile(window, workAreaRect, { openTilingPopup: false, skipAnim: true });
         }
 
     }

--- a/tiling-assistant@leleat-on-github/src/extension/utility.js
+++ b/tiling-assistant@leleat-on-github/src/extension/utility.js
@@ -162,6 +162,19 @@ var Util = class Utility {
     }
 
     /**
+     * Get if maximized gaps are enabled.
+     * 
+     * @returns {boolean}
+     */
+    static isMaximizedGapsEnabled() {
+        const screenTopGap = Settings.getInt(Settings.SCREEN_TOP_GAP);
+        const screenLeftGap = Settings.getInt(Settings.SCREEN_LEFT_GAP);
+        const screenRightGap = Settings.getInt(Settings.SCREEN_RIGHT_GAP);
+        const screenBottomGap = Settings.getInt(Settings.SCREEN_BOTTOM_GAP);
+        return (screenTopGap || screenLeftGap || screenRightGap || screenBottomGap) && Settings.getBoolean(Settings.MAXIMIZE_WITH_GAPS);
+    }
+
+    /**
      * Shows the tiled rects of the top tile group.
      *
      * @returns {St.Widget[]} an array of St.Widgets to indicate the tiled rects.


### PR DESCRIPTION
This should add gaps to windows that are maximized via double-click. This applies only to windows that are designated as normal, but I'm unsure if that is necessary.