### PR TITLE
GNOME 44 support

### DIFF
--- a/tiling-assistant@leleat-on-github/extension.js
+++ b/tiling-assistant@leleat-on-github/extension.js
@@ -66,9 +66,11 @@ function enable() {
     this._gnomeMutterEdgeTilingUserValue = this._gnomeMutterSettings.get_user_value('edge-tiling');
     this._gnomeMutterSettings.set_boolean('edge-tiling', false);
 
-    this._gnomeShellSettings = ExtensionUtils.getSettings('org.gnome.shell.overrides');
-    this._gnomeShellEdgeTilingUserValue = this._gnomeShellSettings.get_user_value('edge-tiling');
-    this._gnomeShellSettings.set_boolean('edge-tiling', false);
+    if (Gio.SettingsSchemaSource.get_default().lookup('org.gnome.shell.overrides', true)) {
+        this._gnomeShellSettings = ExtensionUtils.getSettings('org.gnome.shell.overrides');
+        this._gnomeShellEdgeTilingUserValue = this._gnomeShellSettings.get_user_value('edge-tiling');
+        this._gnomeShellSettings.set_boolean('edge-tiling', false);
+    }
 
     // Disable native keybindings for Super+Up/Down/Left/Right
     this._gnomeMutterKeybindings = ExtensionUtils.getSettings('org.gnome.mutter.keybindings');

--- a/tiling-assistant@leleat-on-github/metadata.json
+++ b/tiling-assistant@leleat-on-github/metadata.json
@@ -2,7 +2,8 @@
   "description": "Expand GNOME's 2 column tiling and add a Windows-snap-assist-inspired popup...",
   "name": "Tiling Assistant",
   "shell-version": [
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/Leleat/Tiling-Assistant",
   "uuid": "tiling-assistant@leleat-on-github",

--- a/tiling-assistant@leleat-on-github/src/extension/activeWindowHint.js
+++ b/tiling-assistant@leleat-on-github/src/extension/activeWindowHint.js
@@ -7,6 +7,7 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 
 const { Settings } = Me.imports.src.common;
+const { Util } = Me.imports.src.extension.utility;
 const Twm = Me.imports.src.extension.tilingWindowManager.TilingWindowManager;
 
 var Handler = class ActiveWindowHintHandler {
@@ -110,7 +111,7 @@ class MinimalActiveWindowHint extends Hint {
 
     _reset() {
         if (this._laterId) {
-            Meta.later_remove(this._laterId);
+            Util.laterRemove(this._laterId);
             delete this._laterId;
         }
         this._windowClone?.destroy();
@@ -199,7 +200,7 @@ class MinimalActiveWindowHint extends Hint {
             return;
 
         if (!this._laterId) {
-            this._laterId = Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
+            this._laterId = Util.laterAdd(Meta.LaterType.BEFORE_REDRAW, () => {
                 global.window_group.set_child_below_sibling(this, actor);
                 delete this._laterId;
                 return false;
@@ -230,9 +231,9 @@ class MinimalActiveWindowHint extends Hint {
 // TODO a solid bg color looks better than a border when launching an app since
 // the border will appear before the window is fully visible. However there was
 // an issue with global.window_group.set_child_below_sibling not putting the hint
-// below the window for some reason. Meta.later_add solved it but I don't know
+// below the window for some reason. Util.laterAdd solved it but I don't know
 // why. So as to not potentially cover the entire window's content use the border
-// style until I figure out if Meta.later_add is the proper solution...
+// style until I figure out if Util.laterAdd is the proper solution...
 const AlwaysHint = GObject.registerClass(
 class AlwaysActiveWindowHint extends Hint {
     _init() {
@@ -282,7 +283,8 @@ class AlwaysActiveWindowHint extends Hint {
         if (!this._showLater)
             return;
 
-        Meta.later_remove(this._showLater);
+
+        Util.laterRemove(this._showLater);
         delete this._showLater;
     }
 
@@ -314,7 +316,7 @@ class AlwaysActiveWindowHint extends Hint {
         if (!actor || this._showLater)
             return;
 
-        this._showLater = Meta.later_add(Meta.LaterType.IDLE, () => {
+        this._showLater = Util.laterAdd(Meta.LaterType.IDLE, () => {
             global.window_group.set_child_below_sibling(this, actor);
             this.show();
             delete this._showLater;

--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -427,7 +427,7 @@ var Handler = class TilingMoveHandler {
     }
 
     _restoreSizeAndRestartGrab(window, px, py, grabOp) {
-        global.display.end_grab_op(global.get_current_time());
+        global.display.end_grab_op?.(global.get_current_time());
 
         const rect = window.get_frame_rect();
         const x = px - rect.x;
@@ -438,6 +438,12 @@ var Handler = class TilingMoveHandler {
             xAnchor: px,
             skipAnim: this._wasMaximizedOnStart
         });
+
+        if (!global.display.begin_grab_op) {
+            this._onMoveStarted(window, grabOp);
+            return;
+        }
+
         // untiledRect is null, if the window was maximized via non-extension
         // way (dblc-ing the titlebar, maximize button...). So just get the
         // restored window's rect directly... doesn't work on Wayland because
@@ -486,7 +492,8 @@ var Handler = class TilingMoveHandler {
                     // Only update the monitorNr, if the latest timer timed out.
                     if (timerId === this._latestMonitorLockTimerId) {
                         this._monitorNr = global.display.get_current_monitor();
-                        if (global.display.get_grab_op() === grabOp) // !
+                        if (global.display.is_grabbed?.() ||
+                            global.display.get_grab_op?.() === grabOp) // !
                             this._edgeTilingPreview(window, grabOp);
                     }
 

--- a/tiling-assistant@leleat-on-github/src/extension/utility.js
+++ b/tiling-assistant@leleat-on-github/src/extension/utility.js
@@ -185,6 +185,29 @@ var Util = class Utility {
     }
 
     /**
+     * Add a Meta.Later depending on the shell version
+     *
+     * @param laterType
+     * @param callback
+     */
+    static laterAdd(laterType, callback) {
+        return global.compositor?.get_laters?.().add(laterType, callback) ??
+            Meta.later_add(laterType, callback);
+    }
+
+    /**
+     * Removes a Meta.Later depending on the shell version
+     *
+     * @param id
+     */
+    static laterRemove(id) {
+        if (global.compositor?.get_laters)
+            global.compositor?.get_laters().remove(id);
+        else
+            Meta.later_remove(id);
+    }
+
+    /**
      * Shows the tiled rects of the top tile group.
      *
      * @returns {St.Widget[]} an array of St.Widgets to indicate the tiled rects.


### PR DESCRIPTION
GNOME removed grab op's manual handling support, but we can avoid them by just adapting the motion.

Tested in both wayland and X11, while I didn't test if older versions could still work using the same codepath (yet).