### PR TITLE
tilingWindowManager: Semi-maximize windows when possible

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -98,7 +98,7 @@ var Handler = class TilingMoveHandler {
         // Also work with a window, which was maximized by GNOME natively
         // because it may have been tiled with this extension before being
         // maximized so we need to restore its size to pre-tiling.
-        this._wasMaximizedOnStart = window.get_maximized();
+        this._wasMaximizedOnStart = window.get_maximized() === Meta.MaximizeFlags.BOTH;
         const [x, y] = global.get_pointer();
 
         // Try to restore the window size

--- a/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
@@ -158,6 +158,8 @@ var TilingWindowManager = class TilingWindowManager {
         const monitor = monitorNr ?? window.get_monitor();
         const workArea = new Rect(window.get_work_area_for_monitor(monitor));
         const maximize = newRect.equal(workArea);
+        const verticalMaximize = !maximize && newRect.height === workArea.height;
+        const horizontalMaximize = !maximize && newRect.width === workArea.width;
 
         window.isTiled = !maximize;
         if (!window.untiledRect)
@@ -193,6 +195,11 @@ var TilingWindowManager = class TilingWindowManager {
                 Meta.SizeChange.MAXIMIZE
             );
         }
+
+        if (verticalMaximize)
+            window.maximize(Meta.MaximizeFlags.VERTICAL);
+        else if (horizontalMaximize)
+            window.maximize(Meta.MaximizeFlags.HORIZONTAL);
 
         // See issue #137.
         // Under some circumstances it's possible that windows will tile to the wrong


### PR DESCRIPTION
When a window is meant to use the whole workarea height or the whole width we can assume that the user wants to semi-maximize the window, so let's communicate this to mutter so that it will apply to the window the proper style, avoiding the window to have shadows or wrongly decorated edges

