### PR TITLE
extension: Add SettingsOverrider to preserve user settings

### DIFF
--- a/tiling-assistant@leleat-on-github/schemas/org.gnome.shell.extensions.tiling-assistant.gschema.xml
+++ b/tiling-assistant@leleat-on-github/schemas/org.gnome.shell.extensions.tiling-assistant.gschema.xml
@@ -279,5 +279,9 @@
 		<key name="last-version-installed" type="i">
 			<default>-1</default>
 		</key>
+		<key name="overridden-settings" type="a{sv}">
+			<!-- Private key for remembering the overridden values -->
+			<default>[]</default>
+		</key>
 	</schema>
 </schemalist>

--- a/tiling-assistant@leleat-on-github/src/common.js
+++ b/tiling-assistant@leleat-on-github/src/common.js
@@ -144,6 +144,14 @@ var Settings = class Settings {
         return this._settings.get_boolean(key);
     }
 
+    static getValue(key) {
+        return this._settings.get_value(key);
+    }
+
+    static getUserValue(key) {
+        return this._settings.get_user_value(key);
+    }
+
     /**
      * Setters
      */
@@ -166,6 +174,14 @@ var Settings = class Settings {
 
     static setBoolean(key, value) {
         this._settings.set_boolean(key, value);
+    }
+
+    static setValue(key, value) {
+        return this._settings.set_value(key, value);
+    }
+
+    static reset(key) {
+        this._settings.reset(key);
     }
 };
 


### PR DESCRIPTION
This is the "hacky" version of #243 in a way that can be supported by current gnome.

---

The extension is overriding the user settings by writing on them, sadly this
implies various issues because even if we reset them on extension unloading,
a shell crash or mis-behavior could always lead to affect user settings.

Tiling assistant replaces the user settings when running, but not to loose the
user settings, we need to save them around so that when the extension gets
unloaded they can be restored.

So add a SettingsOverrider class that:
 - Replaces the user settings with the extensions one
 - Remembers what has been changed and saves it locally and in our settings
 - When the extension is unloaded the settings are restored or reset

Now, in case gnome-shell is stopped or the extension has crashed for some
reason, once the extension is reloaded we check if previous settings were
saved and in case they are used to restore the user settings on destruction.