### PR TITLE
Layouts: Fix position of the search-a-layout popup on multi-monitor setups

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/layoutsManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/layoutsManager.js
@@ -295,13 +295,12 @@ const LayoutSearch = GObject.registerClass({
 }, class TilingLayoutsSearch extends St.Widget {
     _init(layouts) {
         const activeWs = global.workspace_manager.get_active_workspace();
-        const allWorkArea = activeWs.get_work_area_all_monitors();
         super._init({
             reactive: true,
-            x: allWorkArea.x,
-            y: allWorkArea.y,
-            width: allWorkArea.width,
-            height: allWorkArea.height
+            x: Main.uiGroup.x,
+            y: Main.uiGroup.y,
+            width: Main.uiGroup.width,
+            height: Main.uiGroup.height
         });
         Main.uiGroup.add_child(this);
 


### PR DESCRIPTION
While the popup was positioned to be at the center of the current monitor in absolute coords, it was a child of a widget that spanned only the workArea (and not the full monitors). So instead make the parent equal the Main.uiGroup and in turn the global.stage.

Fix https://github.com/Leleat/Tiling-Assistant/issues/241