### PR TITLE
Window Grab Operations: Fix regression for GNOME 44

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -24,6 +24,8 @@ var Handler = class TilingMoveHandler {
 
         this._displaySignals = [];
         const g1Id = global.display.connect('grab-op-begin', (src, window, grabOp) => {
+            grabOp &= ~1024; // META_GRAB_OP_WINDOW_FLAG_UNCONSTRAINED
+
             if (window && moveOps.includes(grabOp))
                 this._onMoveStarted(window, grabOp);
         });

--- a/tiling-assistant@leleat-on-github/src/extension/resizeHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/resizeHandler.js
@@ -45,10 +45,14 @@ var Handler = class TilingResizeHandler {
         };
 
         const g1 = global.display.connect('grab-op-begin', (d, window, grabOp) => {
+            grabOp &= ~1024; // META_GRAB_OP_WINDOW_FLAG_UNCONSTRAINED
+
             if (window && isResizing(grabOp))
                 this._onResizeStarted(window, grabOp);
         });
         const g2 = global.display.connect('grab-op-end', (d, window, grabOp) => {
+            grabOp &= ~1024; // META_GRAB_OP_WINDOW_FLAG_UNCONSTRAINED
+
             if (window && isResizing(grabOp))
                 this._onResizeFinished(window, grabOp);
         });


### PR DESCRIPTION
Mutter introduced a new flag META_GRAB_OP_WINDOW_FLAG_UNCONSTRAINED (1024). It is used to indicate wether a window is unconstrainted during a grab operation e. g. wether it can go under the top bar. As an example, this flag will be set, if you use super+mouse buttons. We currently only check for equality when looking at the Meta.GrabOp instead of using a bitwise or. That's why for simplicitiy's sake, just remove the new flag before working with the grabOp (and take the new flag into account during an upcoming larger refactor).