### PR TITLE
Extension: Properly restore tiling props on all workspaces after unlocking the screen.

### DIFF
--- a/tiling-assistant@leleat-on-github/extension.js
+++ b/tiling-assistant@leleat-on-github/extension.js
@@ -289,7 +289,7 @@ function _saveBeforeSessionLock() {
 
     // can't just check for isTiled because maximized windows may
     // have an untiledRect as well in case window gaps are used
-    const openWindows = this._twm.getWindows(false);
+    const openWindows = this._twm.getWindows(true);
     const savedWindows = openWindows.filter(w => w.untiledRect).map(w => {
         return {
             windowId: w.get_stable_sequence(),
@@ -336,7 +336,7 @@ function _loadAfterSessionLock() {
     if (!success || !contents.length)
         return;
 
-    const openWindows = this._twm.getWindows(false);
+    const openWindows = this._twm.getWindows(true);
     const saveObj = JSON.parse(ByteArray.toString(contents));
 
     const windowObjects = saveObj['windows'];


### PR DESCRIPTION
Fixes https://github.com/Leleat/Tiling-Assistant/issues/258