### PR TITLE
Utils: Fix rounding error in Rect.getUnitAt()

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/utility.js
+++ b/tiling-assistant@leleat-on-github/src/extension/utility.js
@@ -535,20 +535,39 @@ var Rect = class Rect {
      */
     getUnitAt(index, unitSize, orientation) {
         unitSize = Math.floor(unitSize);
-        const isVertical = orientation === Orientation.V;
-        const firstUnitRect = new Rect(
-            this.x,
-            this.y,
-            isVertical ? unitSize : this.width,
-            isVertical ? this.height : unitSize
-        );
 
-        if (index <= 0) {
-            return firstUnitRect;
-        } else {
-            const remaining = this.minus(firstUnitRect)[0];
-            return remaining.getUnitAt(index - 1, unitSize, orientation);
-        }
+        const isVertical = orientation === Orientation.V;
+        const lastIndex = Math.round(this[isVertical ? 'width' : 'height'] / unitSize) - 1;
+
+        const getLastRect = () => {
+            const margin = unitSize * index;
+            return new Rect(
+                isVertical ? this.x + margin : this.x,
+                isVertical ? this.y : this.y + margin,
+                isVertical ? this.width - margin : this.width,
+                isVertical ? this.height : this.height - margin
+            );
+        };
+        const getNonLastRect = (remainingRect, idx) => {
+            const firstUnitRect = new Rect(
+                remainingRect.x,
+                remainingRect.y,
+                isVertical ? unitSize : remainingRect.width,
+                isVertical ? remainingRect.height : unitSize
+            );
+
+            if (idx <= 0) {
+                return firstUnitRect;
+            } else {
+                const remaining = remainingRect.minus(firstUnitRect)[0];
+                return getNonLastRect(remaining, idx - 1);
+            }
+        };
+
+        if (index === lastIndex)
+            return getLastRect();
+        else
+            return getNonLastRect(this, index);
     }
 
     /**


### PR DESCRIPTION
getUnitAt is meant to be used when you need to split a rect into nearly equally sized 'units' e. g. split the workarea in X-number of columns or X-number of rows. It was meant to prevent rounding errors resulting in gaps between rects. All units are equally sized except the last one. The last unit took whatever space was left... and it sorta worked but it could have resulted in the last 'unit rect' potentially being just 1 px wide or high depending on whether the calling rect had an odd or even size.

For instance, Ubuntu 22.04 has a top bar with a height of 27 px. If you tried to tile a window to the bottom half on a 1080 px high screen, the tile would end up 1 px short and you'd leave a gap at the bottom of the screen.

Instead now check whether the unit rect we are looking for is the last unit and size it accordingly.

Related https://github.com/Leleat/Tiling-Assistant/issues/261.