### PR TITLE
fix: ensure the window is moved to the tile's monitor before moving and resizing it

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
@@ -208,6 +208,7 @@ var TilingWindowManager = class TilingWindowManager {
         // to workaround that by first only moving the window and then resizing it. That
         // workaround was already necessary under Wayland because of some apps. E. g.
         // first tiling Nautilus and then Firefox using the Tiling Popup.
+        window.move_to_monitor(monitor);
         window.move_frame(true, x, y);
         window.move_resize_frame(true, x, y, width, height);
 


### PR DESCRIPTION
Fixes #289.

By moving the window to the tile's monitor before moving and resizing fixes the bug. I uploaded a video to show the result:

https://github.com/Leleat/Tiling-Assistant/assets/14203981/2c289578-4051-40cc-a024-659dd57ac889

Tested on:
- Distro (incl. version): Ubuntu 23.04
- GNOME Shell version: 44.3
- Extension version: version 42, and I am on main branch
- Wayland

