### PR TITLE
Metadata: Use version-name instead of version

### DIFF
--- a/scripts/aur-build/PKGBUILD
+++ b/scripts/aur-build/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: VeldoraTheDragon <127216238+VeldoraTheDragon@users.noreply.github.com>
 
 pkgname=gnome-shell-extension-tiling-assistant
-pkgver=46
+pkgver=46.0
 pkgrel=1
 pkgdesc="A GNOME Shell extension to expand GNOME's native 2 column design."
 arch=('x86_64')

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,19 +8,26 @@ SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 cd "$SCRIPT_DIR"/../
 
 METADATA=tiling-assistant@leleat-on-github/metadata.json
+PACKAGE=package.json
 
 # get new version nr
-VERSION_LINE=$(cat $METADATA | grep \"version\":)
+VERSION_LINE=$(cat $METADATA | grep \"version-name\":)
+NEW_VERSION_LINE=$(cat $PACKAGE | grep \"version\":)
 # split after ":" and trim the spaces
 VERSION_NR=$(echo "$VERSION_LINE" | cut -d ':' -f 2 | xargs)
-NEW_VERSION_NR=$((VERSION_NR + 1))
+NEW_VERSION_NR=$(echo "${NEW_VERSION_LINE/,/}" | cut -d ':' -f 2 | xargs)
+
+if [ "$VERSION_NR" = "$NEW_VERSION_NR" ]; then
+    echo "You forgot to increment version number in package.json. Aborting..."
+    exit 1
+fi
 
 # switch to new release branch
 git checkout -b "release-$NEW_VERSION_NR"
 
 # bump up version nr in metadata.json
 echo Updating metadata.json...
-sed -i "s/\"version\": $VERSION_NR/\"version\": $NEW_VERSION_NR/" $METADATA
+sed -i "s/\"version-name\": $VERSION_NR/\"version-name\": $NEW_VERSION_NR/" $METADATA
 echo Metadata updated.
 echo
 
@@ -43,7 +50,7 @@ bash scripts/build.sh
 
 # commit changes
 echo Committing version bump...
-git add $METADATA $PKGBUILD CHANGELOG.md scripts/aur-build/.SRCINFO translations/*.po translations/*.pot
+git add $METADATA $PACKAGE $PKGBUILD CHANGELOG.md scripts/aur-build/.SRCINFO translations/*.po translations/*.pot
 git commit -m "Release: Bump version to $NEW_VERSION_NR"
 echo
 

--- a/tiling-assistant@leleat-on-github/metadata.json
+++ b/tiling-assistant@leleat-on-github/metadata.json
@@ -9,5 +9,5 @@
   "uuid": "tiling-assistant@leleat-on-github",
   "gettext-domain": "tiling-assistant@leleat-on-github",
   "settings-schema": "org.gnome.shell.extensions.tiling-assistant",
-  "version": 46
+  "version-name": "46.0"
 }


### PR DESCRIPTION
EGO and GNOME Shell (46) support a custom version field called `version-name`. `version` is still used internally by EGO and GNOME Shell for updates but it will be automatically inserted into the `metadata.json` file by EGO on upload. So drop `version` now so that we don't need to increment it ourselves anymore.