### PR TITLE
CI: Remove stylelint and use package.json to install deps

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -13,18 +13,12 @@ jobs:
         with:
           node-version: "*"
       - name: Prepare Linters
-        run: npm install -g eslint stylelint stylelint-config-standard && npm i @eslint/js 
+        run: npm i
       - name: Run ESLint (*.js)
         run: >
           git diff --name-only --diff-filter=ACMTUXB origin/${{ github.base_ref }} HEAD |
           grep -E "\.js$" |
           xargs -r eslint
-      - name: Run stylelint (*.css)
-        if: success() || failure()
-        run: >
-          git diff --name-only --diff-filter=ACMTUXB origin/${{ github.base_ref }} HEAD |
-          grep -E "\.css$" |
-          xargs -r stylelint
       - name: Run ShellCheck (*.sh)
         if: success() || failure()
         run: >

--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -1,5 +1,0 @@
-extends: stylelint-config-standard
-rules:
-    # modern and percentage not supported under g-s
-    color-function-notation: legacy
-    alpha-value-notation: number


### PR DESCRIPTION
Since we now have a package.json file just use `npm i` to install the linter(s). Also remove stylelint since it was pretty much unused cause T-A barely uses CSS.