### PR TITLE
Misc: Add translation comments

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -18,7 +18,7 @@ jobs:
         run: >
           git diff --name-only --diff-filter=ACMTUXB origin/${{ github.base_ref }} HEAD |
           grep -E "\.js$" |
-          xargs -r eslint
+          xargs -r npx eslint
       - name: Run ShellCheck (*.sh)
         if: success() || failure()
         run: >

--- a/scripts/update-tl.sh
+++ b/scripts/update-tl.sh
@@ -12,7 +12,11 @@ echo -n Updating \'translations/main.pot\'
 xgettext \
     --from-code=UTF-8 \
     --output=translations/main.pot \
-    ./*/*/*/*.ui ./*/*.js ./*/*/*.js ./*/*/*/*.js
+    --add-comments='Translators:' \
+    ./tiling-assistant@leleat-on-github/*/*/*.ui \
+    ./tiling-assistant@leleat-on-github/*.js \
+    ./tiling-assistant@leleat-on-github/*/*.js \
+    ./tiling-assistant@leleat-on-github/*/*/*.js
 echo \ ......... done.
 
 # update .po files

--- a/tiling-assistant@leleat-on-github/src/extension/keybindingHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/keybindingHandler.js
@@ -53,7 +53,9 @@ export default class TilingKeybindingHandler {
             const toggleTo = !Settings.getBoolean('enable-tiling-popup');
             Settings.setBoolean('enable-tiling-popup', toggleTo);
             Main.notify('Tiling Assistant', toggleTo
+                // Translators: This is the notification text when the Tiling Popup is enabled/disabled via the keyboard shortcut
                 ? _('Tiling popup enabled')
+                // Translators: This is the notification text when the Tiling Popup is enabled/disabled via the keyboard shortcut
                 : _('Tiling popup was disabled'));
             return;
         }

--- a/tiling-assistant@leleat-on-github/src/extension/layoutsManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/layoutsManager.js
@@ -101,6 +101,7 @@ export default class TilingLayoutsManager {
     openPopupSearch() {
         const layouts = Util.getLayouts();
         if (!layouts.length) {
+            // Translators: This is a notification that pops up when a keyboard shortcut to activate a user-defined tiling layout is activated but no layout was defined by the user.
             Main.notify('Tiling Assistant', _('No valid layouts defined.'));
             return;
         }
@@ -192,6 +193,7 @@ export default class TilingLayoutsManager {
     _openAppTiled(appId) {
         const app = Shell.AppSystem.get_default().lookup_app(appId);
         if (!app) {
+            // Translators: This is a notification that pops up when a keyboard shortcut to activate a user-defined tiling layout is activated and the user attached an app to a tile so that a new instance of that app will automatically open in the tile. But that app seems to have been uninstalled since the definition of the layout.
             Main.notify('Tiling Assistant', _('Popup Layouts: App not found.'));
             this._finishLayouting();
             return;
@@ -334,7 +336,7 @@ const LayoutSearch = GObject.registerClass({
             style: `font-size: ${fontSize}px;\
                     border-radius: 16px;
                     margin-bottom: 12px;`,
-            // The cursor overlaps the text, so add some spaces at the beginning
+            // Translators: This is the placeholder text for a search field.
             hint_text: ` ${_('Type to search...')}`
         });
         const entryClutterText = entry.get_clutter_text();
@@ -439,8 +441,7 @@ const SearchItem = GObject.registerClass(
 class TilingLayoutsSearchItem extends St.Label {
     _init(text, fontSize) {
         super._init({
-            // Add some spaces to the beginning to align it better
-            // with the rounded corners
+            // Translators: This is the text that will be displayed as the name of the user-defined tiling layout if it hasn't been given a name.
             text: `   ${text || _('Nameless layout...')}`,
             style: `font-size: ${fontSize}px;\
                 text-align: left;\
@@ -491,6 +492,7 @@ const PanelIndicator = GObject.registerClass({
 
         const layouts = Util.getLayouts();
         if (!layouts.length) {
+            // Translators: This is a placeholder text within a popup, if the user didn't define a tiling layout.
             const item = new PopupMenu.PopupMenuItem(_('No valid layouts defined.'));
             item.setSensitive(false);
             this.menu.addMenuItem(item);

--- a/tiling-assistant@leleat-on-github/src/extension/tileEditingMode.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tileEditingMode.js
@@ -58,6 +58,7 @@ class TileEditingMode extends St.Widget {
 
         const openWindows = Twm.getWindows();
         if (!openWindows.length || !this._windows.length) {
+            // Translators: This is a notification that pops up if the user tries to enter the Tile Editing Mode via a keyboard shortcut.
             const msg = _("Can't enter 'Tile Editing Mode', if no tiled window is visible.");
             Main.notify('Tiling Assistant', msg);
             this.close();

--- a/tiling-assistant@leleat-on-github/src/prefs/layoutRowEntry.js
+++ b/tiling-assistant@leleat-on-github/src/prefs/layoutRowEntry.js
@@ -34,6 +34,7 @@ export const LayoutRowEntry = GObject.registerClass({
         // Show a placeholder on the first entry, if it's empty
         if (!text) {
             if (idx === 0) {
+                // Translators: This is a placeholder text of an entry in the prefs when defining a tiling layout.
                 const placeholder = _("'User Guide' for help...");
                 this._rectEntry.set_placeholder_text(placeholder);
             } else {

--- a/tiling-assistant@leleat-on-github/src/ui/prefs.ui
+++ b/tiling-assistant@leleat-on-github/src/ui/prefs.ui
@@ -7,23 +7,23 @@
   <menu id="info-menu">
     <section>
       <item>
-        <attribute name="label" translatable="yes">Report a Bug</attribute>
+        <attribute name="label" translatable="yes" comments="Translators: This is a popup menu item in the headerbar of the prefs window that links to Github">Report a Bug</attribute>
         <attribute name="action">prefs.open-bug-report</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">User Guide</attribute>
+        <attribute name="label" translatable="yes" comments="Translators: This is a popup menu item in the headerbar of the prefs window that links to Github">User Guide</attribute>
         <attribute name="action">prefs.open-user-guide</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">License</attribute>
+        <attribute name="label" translatable="yes" comments="Translators: This is a popup menu item in the headerbar of the prefs window that links to Github">License</attribute>
         <attribute name="action">prefs.open-license</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">Changelog</attribute>
+        <attribute name="label" translatable="yes" comments="Translators: This is a popup menu item in the headerbar of the prefs window that links to Github">Changelog</attribute>
         <attribute name="action">prefs.open-changelog</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">Advanced...</attribute>
+        <attribute name="label" translatable="yes" comments="Translators: This is a popup menu item in the headerbar of the prefs window that opens a dialog to enable the advanced and experimental settings">Advanced...</attribute>
         <attribute name="action">prefs.open-hidden-settings</attribute>
       </item>
     </section>
@@ -38,22 +38,22 @@
   <!-- = Page: General ======================================================================== -->
   <!-- ======================================================================================== -->
   <object class="AdwPreferencesPage" id="general">
-    <property name="title" translatable="yes">General</property>
+    <property name="title" translatable="yes" comments="Translators: This is the name of a tab in the prefs window">General</property>
     <property name="icon-name">view-app-grid-symbolic</property>
       <!-- ======================================================================================== -->
       <!-- = Group: Tiling Popup ================================================================== -->
       <!-- ======================================================================================== -->
       <child>
         <object class="AdwPreferencesGroup">
-          <property name="title" translatable="yes">Tiling Popup</property>
+          <property name="title" translatable="yes" comments="Translators: This is the header for a preference group in the 'General' tab">Tiling Popup</property>
           <child>
             <object class="AdwSwitchRow" id="enable_tiling_popup">
-              <property name="title" translatable="yes">Open after tiling a window</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting in the 'General' tab that decides whether the Tiling Popup will appear after tiling a window">Open after tiling a window</property>
             </object>
           </child>
           <child>
             <object class="AdwSwitchRow" id="tiling_popup_all_workspace">
-              <property name="title" translatable="yes">Include apps from all workspaces</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting in the 'General' tab about including apps in the Tiling Popup">Include apps from all workspaces</property>
               <property name="sensitive">False</property>
               <property name="sensitive"
                         bind-source="enable_tiling_popup"
@@ -68,11 +68,11 @@
       <!-- ======================================================================================== -->
       <child>
         <object class="AdwPreferencesGroup">
-          <property name="title" translatable="yes">Tile Groups</property>
+          <property name="title" translatable="yes" comments="Translators: This is the header for a preference group in the 'General' tab about grouping tiled windows together">Tile Groups</property>
           <child>
             <object class="AdwSwitchRow" id="disable_tile_groups">
-              <property name="title" translatable="yes">Disable Tile Groups</property>
-              <property name="subtitle" translatable="yes">Tiled windows will no longer adapt their size to other tiled windows nor be raised or resized together. The Dynamic Keybinding Behavior 'Window Focus' and the Tiling Popup will also no longer work.</property>
+              <property name="title" translatable="yes" comments="Translators: This is the name of setting to disable tile groups in the 'General' tab">Disable Tile Groups</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation about the 'Disable Tile Groups' setting">Tiled windows will no longer adapt their size to other tiled windows nor be raised or resized together. The Dynamic Keybinding Behavior 'Window Focus' and the Tiling Popup will also no longer work.</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
                         bind-property="active"
@@ -81,14 +81,14 @@
           </child>
           <child>
             <object class="AdwSwitchRow" id="enable_raise_tile_group">
-              <property name="title" translatable="yes">Raise together</property>
-              <property name="subtitle" translatable="yes">A tile group is created when a window gets tiled. If a tiled window is raised, raise the other windows of its tile group as well</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting in the 'General' tab about raising grouped tiled windows into the foreground together">Raise together</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation for the 'Raise Together' setting">A tile group is created when a window gets tiled. If a tiled window is raised, raise the other windows of its tile group as well</property>
             </object>
           </child>
           <child>
             <object class="AdwSwitchRow" id="tilegroups_in_app_switcher">
-              <property name="title" translatable="yes">App Switcher and Tiling Popup</property>
-              <property name="subtitle" translatable="yes">This could conflict with other App Switcher (a.k.a. alt+Tab) extensions. You may need to re-enable this or the other extension after toggling this setting</property>
+              <property name="title" translatable="yes" comments="Translators: This is a (deprecated) setting under the 'Tile Groups' preference group in the 'General' tab. It's about tile groups appearing grouped together in the App Switcher (Alt-Tab) and the Tiling Popup">App Switcher and Tiling Popup</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation for the 'App Switcher and Tiling Popup' setting">This could conflict with other App Switcher (a.k.a. alt+Tab) extensions. You may need to re-enable this or the other extension after toggling this setting</property>
               <property name="sensitive"
                         bind-source="enable_raise_tile_group"
                         bind-property="active"
@@ -102,10 +102,10 @@
       <!-- ======================================================================================== -->
       <child>
         <object class="AdwPreferencesGroup">
-          <property name="title" translatable="yes">Gaps</property>
+          <property name="title" translatable="yes" comments="Translators: This is a header for a preference group in the 'General' tab to add gaps between tiled windows">Gaps</property>
           <child>
             <object class="AdwSpinRow" id="window_gap">
-              <property name="title" translatable="yes">Windows</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting under the 'Gaps' preference group in the 'General' tab to set the gaps between tiled windows">Windows</property>
               <property name="activatable-widget">window_gap</property>
               <property name="adjustment">
                 <object class="GtkAdjustment">
@@ -118,7 +118,7 @@
           </child>
           <child>
             <object class="AdwSpinRow" id="single_screen_gap">
-              <property name="title" translatable="yes">Screen Edges</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting under the 'Gaps' preference group in the 'General' tab to set the gaps between tiled windows and the screen edges">Screen Edges</property>
               <property name="activatable-widget">single_screen_gap</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
@@ -135,7 +135,7 @@
           </child>
           <child>
             <object class="AdwSpinRow" id="screen_top_gap">
-              <property name="title" translatable="yes">Screen Edge Top</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting under the 'Gaps' preference group in the 'General' tab to set the gaps between tiled windows and the top screen edge">Screen Edge Top</property>
               <property name="activatable-widget">screen_top_gap</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
@@ -152,7 +152,7 @@
           </child>
           <child>
             <object class="AdwSpinRow" id="screen_left_gap">
-              <property name="title" translatable="yes">Screen Edge Left</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting under the 'Gaps' preference group in the 'General' tab to set the gaps between tiled windows and the left screen edge">Screen Edge Left</property>
               <property name="activatable-widget">screen_left_gap</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
@@ -169,7 +169,7 @@
           </child>
           <child>
             <object class="AdwSpinRow" id="screen_right_gap">
-              <property name="title" translatable="yes">Screen Edge Right</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting under the 'Gaps' preference group in the 'General' tab to set the gaps between tiled windows and the right screen edge">Screen Edge Right</property>
               <property name="activatable-widget">screen_right_gap</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
@@ -186,7 +186,7 @@
           </child>
           <child>
             <object class="AdwSpinRow" id="screen_bottom_gap">
-              <property name="title" translatable="yes">Screen Edge Bottom</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting under the 'Gaps' preference group in the 'General' tab to set the gaps between tiled windows and the bottom screen edge">Screen Edge Bottom</property>
               <property name="activatable-widget">screen_bottom_gap</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
@@ -203,7 +203,7 @@
           </child>
           <child>
             <object class="AdwSwitchRow" id="maximize_with_gap">
-              <property name="title" translatable="yes">Maximized Windows</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting under the 'Gaps' preference group in the 'General' tab to add gaps between maximized windows and the screen edges">Maximized Windows</property>
             </object>
           </child>
         </object>
@@ -213,12 +213,12 @@
       <!-- ======================================================================================== -->
       <child>
         <object class="AdwPreferencesGroup">
-          <property name="title" translatable="yes">Dynamic Keybinding Behavior</property>
-          <property name="description" translatable="yes">The keybindings to maximize and tile to the top/bottom/left/right may change their behavior based on the window's tiling state</property>
+          <property name="title" translatable="yes" comments="Translators: This is a header for a preference group in the 'General' tab">Dynamic Keybinding Behavior</property>
+          <property name="description" translatable="yes" comments="Translators: This is the explanation for the preference group 'Dynamic Keybinding Behavior' in the 'General' tab">The keybindings to maximize and tile to the top/bottom/left/right may change their behavior based on the window's tiling state</property>
           <child>
             <object class="AdwActionRow" id="dynamic_keybinding_disabled_row">
-              <property name="title" translatable="yes">Disabled</property>
-              <property name="subtitle" translatable="yes">Don't change the keybindings' behavior</property>
+              <property name="title" translatable="yes" comments="Translators: This setting disables the 'Dynamic Keybinding Behavior' in the 'General' tab">Disabled</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation for the 'Disabled' option for the 'Dynamic Keybinding Behavior' in the 'General' tab">Don't change the keybindings' behavior</property>
               <property name="activatable-widget">dynamic_keybinding_disabled_button</property>
               <child type="prefix">
                 <object class="GtkCheckButton" id="dynamic_keybinding_disabled_button"/>
@@ -227,8 +227,8 @@
           </child>
           <child>
             <object class="AdwActionRow" id="dynamic_keybinding_window_focus_row">
-              <property name="title" translatable="yes">Window Focus</property>
-              <property name="subtitle" translatable="yes">Switch focus to the tiled window in the direction of the pressed shortcut</property>
+              <property name="title" translatable="yes" comments="Translators: This setting is under the preference group 'Dynamic Keybinding Behavior' in the 'General' tab. It causes some shortcuts to change window focus instead of tiling">Window Focus</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation for the 'Window Focus' option for the 'Dynamic Keybinding Behavior' in the 'General' tab">Switch focus to the tiled window in the direction of the pressed shortcut</property>
               <property name="activatable-widget">dynamic_keybinding_window_focus_button</property>
               <child type="prefix">
                 <object class="GtkCheckButton" id="dynamic_keybinding_window_focus_button">
@@ -239,8 +239,8 @@
           </child>
           <child>
             <object class="AdwActionRow" id="dynamic_keybinding_tiling_state_row">
-              <property name="title" translatable="yes">Tiling State</property>
-              <property name="subtitle" translatable="yes">Adapt the tiling state to the pressed shortcut. For instance, a window tiled to the right half will tile to the bottom-right quarter, if 'tile to bottom' is activated</property>
+              <property name="title" translatable="yes" comments="Translators: This setting is under the preference group 'Dynamic Keybinding Behavior' in the 'General' tab. It causes some shortcuts to change their tiling behavior based on the current windows' tiling state">Tiling State</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation for the 'Tiling State' option for the 'Dynamic Keybinding Behavior' in the 'General' tab">Adapt the tiling state to the pressed shortcut. For instance, a window tiled to the right half will tile to the bottom-right quarter, if 'tile to bottom' is activated</property>
               <property name="activatable-widget">dynamic_keybinding_tiling_state_button</property>
               <child type="prefix">
                 <object class="GtkCheckButton" id="dynamic_keybinding_tiling_state_button">
@@ -251,8 +251,8 @@
           </child>
           <child>
             <object class="AdwActionRow" id="dynamic_keybinding_tiling_state_windows_row">
-              <property name="title" translatable="yes">Tiling State (Windows)</property>
-              <property name="subtitle" translatable="yes">Like 'Tiling State' but if the window isn't tiled or is already tiled to the bottom and the 'tile to bottom' shortcut is activated, minimize the window</property>
+              <property name="title" translatable="yes" comments="Translators: This setting is under the preference group 'Dynamic Keybinding Behavior' in the 'General' tab. It causes some shortcuts to change their tiling behavior based on the current windows' tiling state. It behaves similarly to Windows (the OS).">Tiling State (Windows)</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation for the 'Tiling State (Windows)' option for the 'Dynamic Keybinding Behavior' in the 'General' tab">Like 'Tiling State' but if the window isn't tiled or is already tiled to the bottom and the 'tile to bottom' shortcut is activated, minimize the window</property>
               <property name="activatable-widget">dynamic_keybinding_tiling_state_windows_button</property>
               <child type="prefix">
                 <object class="GtkCheckButton" id="dynamic_keybinding_tiling_state_windows_button">
@@ -263,8 +263,8 @@
           </child>
           <child>
             <object class="AdwActionRow" id="dynamic_keybinding_favorite_layout_row">
-              <property name="title" translatable="yes">Favorite Layout</property>
-              <property name="subtitle" translatable="yes">Move the window along your favorite Layout</property>
+              <property name="title" translatable="yes" comments="Translators: This setting is under the preference group 'Dynamic Keybinding Behavior' in the 'General' tab. It will change some tiling shortcuts to shift the current window along the 'Favorite Layout' instead of the default half/quarter tiling">Favorite Layout</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation for the 'Favorite Layout' option for the 'Dynamic Keybinding Behavior' in the 'General' tab">Move the window along your favorite Layout</property>
               <property name="activatable-widget">dynamic_keybinding_favorite_layout_button</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
@@ -284,11 +284,11 @@
       <!-- ======================================================================================== -->
       <child>
         <object class="AdwPreferencesGroup">
-        <property name="title" translatable="yes">Active Window Hint</property>
+        <property name="title" translatable="yes" comments="Translators: This is a header for a preference group in the 'General' tab">Active Window Hint</property>
           <child>
             <object class="AdwActionRow" id="active_window_hint_disabled_row">
-              <property name="title" translatable="yes">Disabled</property>
-              <property name="subtitle" translatable="yes">Don't indicate the focused window</property>
+              <property name="title" translatable="yes" comments="Translators: This setting disables the 'Active Window Hint' in the 'General' tab">Disabled</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation for the 'Disabled' option for the 'Active Window Hint' in the 'General' tab">Don't indicate the focused window</property>
               <property name="activatable-widget">active_window_hint_disabled_button</property>
               <child type="prefix">
                 <object class="GtkCheckButton" id="active_window_hint_disabled_button"/>
@@ -297,8 +297,8 @@
           </child>
           <child>
             <object class="AdwActionRow" id="active_window_hint_minimal_row">
-              <property name="title" translatable="yes">Minimal</property>
-              <property name="subtitle" translatable="yes">Temporarily indicate the focused window when switching to a workspace with multiple non-overlapping windows</property>
+              <property name="title" translatable="yes" comments="Translators: This is an option for 'Active Window Hint' in the 'General' tab. With it enabled the active (i. e. focused) window will be indicated under certain circumenstances. E. g. when switching workspaces.">Minimal</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation for the 'Minimal' option for the 'Active Window Hint' in the 'General' tab">Temporarily indicate the focused window when switching to a workspace with multiple non-overlapping windows</property>
               <property name="activatable-widget">active_window_hint_minimal_button</property>
               <child type="prefix">
                 <object class="GtkCheckButton" id="active_window_hint_minimal_button">
@@ -309,8 +309,8 @@
           </child>
           <child>
             <object class="AdwActionRow" id="active_window_hint_always_row">
-              <property name="title" translatable="yes">Always</property>
-              <property name="subtitle" translatable="yes">Always indicate the focused window unless it's maximized or in fullscreen. There are issues on Wayland with GTK4 popups</property>
+              <property name="title" translatable="yes" comments="Translators: This is an option for 'Active Window Hint' in the 'General' tab. With it enabled the active (i. e. focused) window will always be indicated with a frame.">Always</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation for the 'Always' option for the 'Active Window Hint' in the 'General' tab">Always indicate the focused window unless it's maximized or in fullscreen. There are issues on Wayland with GTK4 popups</property>
               <property name="activatable-widget">active_window_hint_always_button</property>
               <child type="prefix">
                 <object class="GtkCheckButton" id="active_window_hint_always_button">
@@ -329,8 +329,8 @@
                     bind-flags="sync-create"/>
           <child>
             <object class="AdwActionRow" id="active_window_hint_color_row">
-              <property name="title" translatable="yes">Hint Color</property>
-              <property name="subtitle" translatable="yes">The color of the frame indicating the focused window</property>
+              <property name="title" translatable="yes" comments="Translators: This is the color of the active window hint in the preference group 'Active Window Hint' in the 'General' tab">Hint Color</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation for the active window 'Hint Color' in the preference group 'Active Window Hint' in the 'General' tab">The color of the frame indicating the focused window</property>
               <property name="activatable-widget">active_window_hint_color_button</property>
               <child>
                 <object class="GtkColorButton" id="active_window_hint_color_button">
@@ -341,8 +341,8 @@
           </child>
           <child>
             <object class="AdwSpinRow" id="active_window_hint_border_size">
-              <property name="title" translatable="yes">Border Size</property>
-              <property name="subtitle" translatable="yes">The border size of the frame indicating the focused window for the always active hint</property>
+              <property name="title" translatable="yes" comments="Translators: This is the border size of the 'Always' active window hint in the preference group 'Active Window Hint' in the 'General' tab">Border Size</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation for the 'Border size' setting of the 'Always' active window hint in the preference group 'Active Window Hint' in the 'General' tab">The border size of the frame indicating the focused window for the always active hint</property>
               <property name="activatable-widget">active_window_hint_border_size</property>
               <property name="adjustment">
                 <object class="GtkAdjustment">
@@ -355,8 +355,8 @@
           </child>
           <child>
             <object class="AdwSpinRow" id="active_window_hint_inner_border_size">
-              <property name="title" translatable="yes">Inner Border Size</property>
-              <property name="subtitle" translatable="yes">The border for the always active hint reaching inside the window frame. This is meant to cover rounded corners. However, GTK4 popups on Wayland will put the window behind the hint for whatever reason...</property>
+              <property name="title" translatable="yes" comments="Translators: This is the border size, that grows into and overlaps the window, of the 'Always' active window hint in the preference group 'Active Window Hint' in the 'General' tab">Inner Border Size</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation for the 'Inner Border size' setting of the 'Always' active window hint in the preference group 'Active Window Hint' in the 'General' tab">The border for the always active hint reaching inside the window frame. This is meant to cover rounded corners. However, GTK4 popups on Wayland will put the window behind the hint for whatever reason...</property>
               <property name="activatable-widget">active_window_hint_inner_border_size</property>
               <property name="adjustment">
                 <object class="GtkAdjustment">
@@ -374,19 +374,19 @@
       <!-- ======================================================================================== -->
       <child>
         <object class="AdwPreferencesGroup">
-          <property name="title" translatable="yes">Animations</property>
+          <property name="title" translatable="yes" comments="Translators: This is a header for a preference group in the 'General' tab">Animations</property>
           <property name="visible"
                     bind-source="enable_advanced_experimental_features"
                     bind-property="active"
                     bind-flags="sync-create"/>
           <child>
             <object class="AdwSwitchRow" id="enable_tile_animations">
-              <property name="title" translatable="yes">Tiling</property>
+              <property name="title" translatable="yes" comments="Translators: This setting enables tiling animations and is listed under the 'Animation' preference group in the 'General' tab">Tiling</property>
             </object>
           </child>
           <child>
             <object class="AdwSwitchRow" id="enable_untile_animations">
-              <property name="title" translatable="yes">Untiling</property>
+              <property name="title" translatable="yes" comments="Translators: This setting enables untiling animations and is listed under the 'Animation' preference group in the 'General' tab">Untiling</property>
             </object>
           </child>
         </object>
@@ -396,16 +396,16 @@
       <!-- ======================================================================================== -->
       <child>
         <object class="AdwPreferencesGroup">
-          <property name="title" translatable="yes">Default Window Movement Mode</property>
-          <property name="description" translatable="yes">The movement mode that is activated when no modifier key is pressed</property>
+          <property name="title" translatable="yes" comments="Translators: This is a header for a preference group in the 'General' tab. See https://github.com/Leleat/Tiling-Assistant/wiki/Window-Grab-Modes for more information">Default Window Movement Mode</property>
+          <property name="description" translatable="yes" comments="Translators: This is the explanation for the preference group 'Default Window Movement Mode' in the 'General' tab">The movement mode that is activated when no modifier key is pressed</property>
           <property name="visible"
                     bind-source="enable_advanced_experimental_features"
                     bind-property="active"
                     bind-flags="sync-create"/>
           <child>
             <object class="AdwActionRow" id="edge_tiling_row">
-              <property name="title" translatable="yes">Edge Tiling</property>
-              <property name="subtitle" translatable="yes">Moving the window to the screen edges or corners will open the default tile preview</property>
+              <property name="title" translatable="yes" comments="Translators: This is an option for the preference group 'Default Window Movement Mode' in the 'General' tab. In this mode, tiling will be activated, when the user drags a window to the screen edges">Edge Tiling</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is the explanation for the 'Edge Tiling' option in the preference group 'Default Window Movement Mode' in the 'General' tab">Moving the window to the screen edges or corners will open the default tile preview</property>
               <property name="activatable-widget">edge_tiling_checkbutton</property>
               <child type="prefix">
                 <object class="GtkCheckButton" id="edge_tiling_checkbutton"/>
@@ -414,8 +414,8 @@
           </child>
           <child>
             <object class="AdwActionRow" id="adaptive_tiling_row">
-              <property name="title" translatable="yes">Adaptive Tiling</property>
-              <property name="subtitle" translatable="yes">Releasing the grab on a window while hovering over a tile will push the overlapped window(s) aside</property>
+              <property name="title" translatable="yes" comments="Translators: This is an option for the preference group 'Default Window Movement Mode' in the 'General' tab. In this mode, tiling a window may affect the current visible layout. E. g. A half-screen tile can be split into 2 quarter tiles">Adaptive Tiling</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is the explanation for the 'Adaptive Tiling' option in the preference group 'Default Window Movement Mode' in the 'General' tab">Releasing the grab on a window while hovering over a tile will push the overlapped window(s) aside</property>
               <property name="activatable-widget">adaptive_tiling_checkbutton</property>
               <child type="prefix">
                 <object class="GtkCheckButton" id="adaptive_tiling_checkbutton">
@@ -426,8 +426,8 @@
           </child>
           <child>
             <object class="AdwActionRow" id="favorite_layout_row">
-              <property name="title" translatable="yes">Favorite Layout</property>
-              <property name="subtitle" translatable="yes">The tile preview will stick to your favorite layout from the 'Layouts' page</property>
+              <property name="title" translatable="yes" comments="Translators: This is an option for the preference group 'Default Window Movement Mode' in the 'General' tab. In this mode, windows can only be tiled to tiles in the favorite layout when using the mouse">Favorite Layout</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is the explanation for the 'Favorite Layout' option in the preference group 'Default Window Movement Mode' in the 'General' tab">The tile preview will stick to your favorite layout from the 'Layouts' page</property>
               <property name="activatable-widget">favorite_layout_checkbutton</property>
               <child type="prefix">
                 <object class="GtkCheckButton" id="favorite_layout_checkbutton">
@@ -438,8 +438,8 @@
           </child>
           <child>
             <object class="AdwActionRow" id="ignore_ta_row">
-              <property name="title" translatable="yes">Ignore Tiling Assistant</property>
-              <property name="subtitle" translatable="yes">Use Edge Tiling without Tiling Assistant's features</property>
+              <property name="title" translatable="yes" comments="Translators: This is an option for the preference group 'Default Window Movement Mode' in the 'General' tab. In this mode core features (Tiling Popup and Tile Groups) will be disabled">Ignore Tiling Assistant</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is the explanation for the 'Ignore Tiling Assistant' option in the preference group 'Default Window Movement Mode' in the 'General' tab">Use Edge Tiling without Tiling Assistant's features</property>
               <property name="activatable-widget">ignore_ta_checkbutton</property>
               <child type="prefix">
                 <object class="GtkCheckButton" id="ignore_ta_checkbutton">
@@ -455,17 +455,17 @@
       <!-- ======================================================================================== -->
       <child>
         <object class="AdwPreferencesGroup">
-          <property name="title" translatable="yes">Other</property>
+          <property name="title" translatable="yes" comments="Translators: This is a header for misc settings in the 'General' tab">Other</property>
           <child>
             <object class="AdwSwitchRow" id="monitor_switch_grace_period">
-              <property name="title" translatable="yes">Monitor Switch Grace Period</property>
-              <property name="subtitle" translatable="yes">When a window is dragged to a new monitor the tile preview will stick to the old monitor for a very short time. This way you can tile windows by 'throwing' it towards any screen edge even if a monitor is bordering that edge.</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting in the 'Other' preference group in the 'General' tab. When moving a window to a new monitor the tiling preview will stick for a short time (the 'Monitor Switch Grace Period') to the old monitor to make tiling on multi-monitor setups easier">Monitor Switch Grace Period</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is the explanation for the 'Monitor Switch Grace Period' under the 'Other' preference group in the 'General' tab">When a window is dragged to a new monitor the tile preview will stick to the old monitor for a very short time. This way you can tile windows by 'throwing' it towards any screen edge even if a monitor is bordering that edge.</property>
             </object>
           </child>
           <child>
             <object class="AdwSwitchRow" id="low_performance_move_mode">
-              <property name="title" translatable="yes">Low Performance Movement Mode</property>
-              <property name="subtitle" translatable="yes">Use this if there is a lag when moving windows around. This will however decrease the precision of the tile preview updates.</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting in the 'Other' preference group in the 'General' tab. If the user has performance issue when dragging windows around, this will improve it but will decrease the accuracy of the tiling previews">Low Performance Movement Mode</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is the explanation for the 'Low Performance Movement Mode' under the 'Other' preference group in the 'General' tab">Use this if there is a lag when moving windows around. This will however decrease the precision of the tile preview updates.</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
                         bind-property="active"
@@ -474,7 +474,7 @@
           </child>
           <child>
             <object class="AdwSwitchRow" id="adapt_edge_tiling_to_favorite_layout">
-              <property name="title" translatable="yes">Adapt 'Edge Tiling' to your Favorite Layout</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting in the 'Other' preference group in the 'General' tab. With this setting enabled, dragging windows to the screen edges won't use the default half-screen tiles but the tiles from the favorite layout">Adapt 'Edge Tiling' to your Favorite Layout</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
                         bind-property="active"
@@ -483,7 +483,7 @@
           </child>
           <child>
             <object class="AdwComboRow" id="move_adaptive_tiling_mod">
-              <property name="title" translatable="yes">'Adaptive Tiling' Move Mode Activator</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting in the 'Other' preference group in the 'General' tab. This will set the modifier to activate the move mode 'Adaptive Tiling'">'Adaptive Tiling' Move Mode Activator</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
                         bind-property="active"
@@ -491,11 +491,11 @@
               <property name="model">
                 <object class="GtkStringList">
                   <items>
-                    <item translatable="yes">Disabled</item>
-                    <item translatable="yes">Ctrl</item>
-                    <item translatable="yes">Alt</item>
-                    <item translatable="yes">RMB</item>
-                    <item translatable="yes">Super</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab">Disabled</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab">Ctrl</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab">Alt</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab. RMB refers to the right mouse button">RMB</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab">Super</item>
                   </items>
                 </object>
               </property>
@@ -503,7 +503,7 @@
           </child>
           <child>
             <object class="AdwComboRow" id="move_favorite_layout_mod">
-              <property name="title" translatable="yes">'Favorite Layout' Move Mode Activator</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting in the 'Other' preference group in the 'General' tab. This will set the modifier to activate the move mode 'Favorite Layout'">'Favorite Layout' Move Mode Activator</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
                         bind-property="active"
@@ -511,11 +511,11 @@
               <property name="model">
                 <object class="GtkStringList">
                   <items>
-                    <item translatable="yes">Disabled</item>
-                    <item translatable="yes">Ctrl</item>
-                    <item translatable="yes">Alt</item>
-                    <item translatable="yes">RMB</item>
-                    <item translatable="yes">Super</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab">Disabled</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab">Ctrl</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab">Alt</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab. RMB refers to the right mouse button">RMB</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab">Super</item>
                   </items>
                 </object>
               </property>
@@ -523,7 +523,7 @@
           </child>
           <child>
             <object class="AdwComboRow" id="ignore_ta_mod">
-              <property name="title" translatable="yes">'Ignore Tiling Assistant' Mode Activator</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting in the 'Other' preference group in the 'General' tab. This will set the modifier to activate the move mode 'Ignore Tiling Assistant'">'Ignore Tiling Assistant' Mode Activator</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
                         bind-property="active"
@@ -531,11 +531,11 @@
               <property name="model">
                 <object class="GtkStringList">
                   <items>
-                    <item translatable="yes">Disabled</item>
-                    <item translatable="yes">Ctrl</item>
-                    <item translatable="yes">Alt</item>
-                    <item translatable="yes">RMB</item>
-                    <item translatable="yes">Super</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab">Disabled</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab">Ctrl</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab">Alt</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab. RMB refers to the right mouse button">RMB</item>
+                    <item translatable="yes" comments="Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab">Super</item>
                   </items>
                 </object>
               </property>
@@ -543,7 +543,7 @@
           </child>
           <child>
             <object class="AdwSpinRow" id="vertical_preview_area">
-              <property name="title" translatable="yes">Vertical Edge Preview Trigger Area</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting in the 'Other' preference group in the 'General' tab. This is the area (in pixels) around the screen edges on the vertical axis that activates the tile previews">Vertical Edge Preview Trigger Area</property>
               <property name="activatable-widget">vertical_preview_area</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
@@ -561,7 +561,7 @@
           </child>
           <child>
             <object class="AdwSpinRow" id="horizontal_preview_area">
-              <property name="title" translatable="yes">Horizontal Edge Preview Trigger Area</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting in the 'Other' preference group in the 'General' tab. This is the area (in pixels) around the screen edges on the horizontal axis that activates the tile previews">Horizontal Edge Preview Trigger Area</property>
               <property name="activatable-widget">horizontal_preview_area</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
@@ -579,7 +579,7 @@
           </child>
           <child>
             <object class="AdwSpinRow" id="toggle_maximize_tophalf_timer">
-              <property name="title" translatable="yes">Inverse Top Screen Edge Action Timer</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting in the 'Other' preference group in the 'General' tab. By default, when using 'Edge Tiling' and dragging the window to the top screen edge, the maximize tiling preview will show up. After some time the preview will switch to the top-half-screen tiling preview. This setting determines the duration of that timer">Inverse Top Screen Edge Action Timer</property>
               <property name="activatable-widget">toggle_maximize_tophalf_timer</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
@@ -597,7 +597,7 @@
           </child>
           <child>
             <object class="AdwSwitchRow" id="enable_hold_maximize_inverse_landscape">
-              <property name="title" translatable="yes">Inverse Top Screen Edge Action for Landscape Displays</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting in the 'Other' preference group in the 'General' tab. By default, when using 'Edge Tiling' and dragging the window to the top screen edge, the maximize tiling preview will show up. After some time the preview will switch to the top-half-screen tiling preview. This setting makes the top-half-screen tiling preview before the maxmize preview on landscape displays">Inverse Top Screen Edge Action for Landscape Displays</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
                         bind-property="active"
@@ -606,7 +606,7 @@
           </child>
           <child>
             <object class="AdwSwitchRow" id="enable_hold_maximize_inverse_portrait">
-              <property name="title" translatable="yes">Inverse Top Screen Edge Action for Portrait Displays</property>
+              <property name="title" translatable="yes" comments="Translators: This is a setting in the 'Other' preference group in the 'General' tab. By default, when using 'Edge Tiling' and dragging the window to the top screen edge, the maximize tiling preview will show up. After some time the preview will switch to the top-half-screen tiling preview. This setting makes the top-half-screen tiling preview before the maxmize preview on portrait displays">Inverse Top Screen Edge Action for Portrait Displays</property>
               <property name="visible"
                         bind-source="enable_advanced_experimental_features"
                         bind-property="active"
@@ -621,34 +621,34 @@
   <!-- = Page: Keybindings ==================================================================== -->
   <!-- ======================================================================================== -->
   <object class="AdwPreferencesPage" id="keybindings">
-    <property name="title" translatable="yes">Keybindings</property>
+    <property name="title" translatable="yes" comments="Translators: This is the name of a tab in the prefs window">Keybindings</property>
     <property name="icon-name">preferences-desktop-keyboard-symbolic</property>
     <!-- ======================================================================================== -->
     <!-- = Group: General ======================================================================= -->
     <!-- ======================================================================================== -->
     <child>
       <object class="AdwPreferencesGroup">
-        <property name="title" translatable="yes">General</property>
+        <property name="title" translatable="yes" comments="Translators: This is a header for a preference group in the 'Keybindings' tab">General</property>
         <child>
           <object class="ShortcutListener" id="toggle_tiling_popup">
-            <property name="title" translatable="yes">Toggle 'Tiling Popup'</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab that enables/disables the appearance of the Tiling Popup after a window is tiled">Toggle 'Tiling Popup'</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="tile_edit_mode">
-            <property name="title" translatable="yes">Tile Editing Mode</property>
-            <property name="subtitle" translatable="yes">A keyboard-driven mode to manage your tiled windows</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab that activates the 'Tile Editing Mode'">Tile Editing Mode</property>
+            <property name="subtitle" translatable="yes" comments="Translators: This is the explanation for the keybinding 'Tile Editing Mode' in the 'General' preference group in the 'Keybindings' tab">A keyboard-driven mode to manage your tiled windows</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="auto_tile">
-            <property name="title" translatable="yes">Auto-Tile</property>
-            <property name="subtitle" translatable="yes">Un/tile the current window based on the visible tiles</property>
+            <property name="title" translatable="yes" comments="Translators: This is a (deprecated) keybinding in the 'General' preference group in the 'Keybindings' tab. Its name is a bit misleading. The keybinding will only tile 1 window. Its behavior depends on the current tiling layout. It may cause a window to fill the main empty space or untile a window">Auto-Tile</property>
+            <property name="subtitle" translatable="yes" comments="Translators: This is the explanation for the keybinding 'Auto-Tile' in the 'General' preference group in the 'Keybindings' tab">Un/tile the current window based on the visible tiles</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="toggle_always_on_top">
-            <property name="title" translatable="yes">Toggle 'Always on Top'</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab">Toggle 'Always on Top'</property>
             <property name="visible"
                       bind-source="enable_advanced_experimental_features"
                       bind-property="active"
@@ -657,12 +657,12 @@
         </child>
         <child>
           <object class="ShortcutListener" id="tile_maximize">
-            <property name="title" translatable="yes">Toggle Maximization</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab">Toggle Maximization</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="tile_maximize_vertically">
-            <property name="title" translatable="yes">Toggle Vertical Maximization</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab">Toggle Vertical Maximization</property>
             <property name="visible"
                       bind-source="enable_advanced_experimental_features"
                       bind-property="active"
@@ -671,7 +671,7 @@
         </child>
         <child>
           <object class="ShortcutListener" id="tile_maximize_horizontally">
-            <property name="title" translatable="yes">Toggle Horizontal Maximization</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab">Toggle Horizontal Maximization</property>
             <property name="visible"
                       bind-source="enable_advanced_experimental_features"
                       bind-property="active"
@@ -680,12 +680,12 @@
         </child>
         <child>
           <object class="ShortcutListener" id="restore_window">
-            <property name="title" translatable="yes">Restore Window Size</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab">Restore Window Size</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="center_window">
-            <property name="title" translatable="yes">Move Window to Center</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab">Move Window to Center</property>
           </object>
         </child>
       </object>
@@ -695,25 +695,25 @@
     <!-- ======================================================================================== -->
     <child>
       <object class="AdwPreferencesGroup">
-        <property name="title" translatable="yes">Edge Tiling</property>
+        <property name="title" translatable="yes" comments="Translators: This is a header for a preference group in the 'Keybindings' tab to tile windows to the screen halves">Edge Tiling</property>
         <child>
           <object class="ShortcutListener" id="tile_top_half">
-            <property name="title" translatable="yes">Tile to top</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Edge Tiling' preference group in the 'Keybindings' tab to tile window to the top screen half">Tile to top</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="tile_bottom_half">
-            <property name="title" translatable="yes">Tile to bottom</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Edge Tiling' preference group in the 'Keybindings' tab to tile window to the bottom screen half">Tile to bottom</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="tile_left_half">
-            <property name="title" translatable="yes">Tile to left</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Edge Tiling' preference group in the 'Keybindings' tab to tile window to the left screen half">Tile to left</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="tile_right_half">
-            <property name="title" translatable="yes">Tile to right</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Edge Tiling' preference group in the 'Keybindings' tab to tile window to the right screen half">Tile to right</property>
           </object>
         </child>
       </object>
@@ -723,25 +723,25 @@
     <!-- ======================================================================================== -->
     <child>
       <object class="AdwPreferencesGroup">
-        <property name="title" translatable="yes">Corner Tiling</property>
+        <property name="title" translatable="yes" comments="Translators: This is a header for a preference group in the 'Keybindings' tab to tile windows to quarters">Corner Tiling</property>
         <child>
           <object class="ShortcutListener" id="tile_topleft_quarter">
-            <property name="title" translatable="yes">Tile to top-left</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Corner Tiling' preference group in the 'Keybindings' tab to tile window to the top left quarter">Tile to top-left</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="tile_topright_quarter">
-            <property name="title" translatable="yes">Tile to top-right</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Corner Tiling' preference group in the 'Keybindings' tab to tile window to the top right quarter">Tile to top-right</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="tile_bottomleft_quarter">
-            <property name="title" translatable="yes">Tile to bottom-left</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Corner Tiling' preference group in the 'Keybindings' tab to tile window to the bottom left quarter">Tile to bottom-left</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="tile_bottomright_quarter">
-            <property name="title" translatable="yes">Tile to bottom-right</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Corner Tiling' preference group in the 'Keybindings' tab to tile window to the bottom right quarter">Tile to bottom-right</property>
           </object>
         </child>
       </object>
@@ -751,29 +751,29 @@
     <!-- ======================================================================================== -->
     <child>
       <object class="AdwPreferencesGroup">
-        <property name="title" translatable="yes">Edge Tiling without Tiling Assistant</property>
+        <property name="title" translatable="yes" comments="Translators: This is a header for a preference group in the 'Keybindings' tab to tile windows to screen halves without spawning a Tiling Popup">Edge Tiling without Tiling Assistant</property>
         <property name="visible"
                   bind-source="enable_advanced_experimental_features"
                   bind-property="active"
                   bind-flags="sync-create"/>
         <child>
           <object class="ShortcutListener" id="tile_top_half_ignore_ta">
-            <property name="title" translatable="yes">Tile to top</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Edge Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the top screen half without spawning a Tiling Popup">Tile to top</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="tile_bottom_half_ignore_ta">
-            <property name="title" translatable="yes">Tile to bottom</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Edge Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the bottom screen half without spawning a Tiling Popup">Tile to bottom</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="tile_left_half_ignore_ta">
-            <property name="title" translatable="yes">Tile to left</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Edge Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the left screen half without spawning a Tiling Popup">Tile to left</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="tile_right_half_ignore_ta">
-            <property name="title" translatable="yes">Tile to right</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Edge Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the right screen half without spawning a Tiling Popup">Tile to right</property>
           </object>
         </child>
       </object>
@@ -783,29 +783,29 @@
     <!-- ======================================================================================== -->
     <child>
       <object class="AdwPreferencesGroup">
-        <property name="title" translatable="yes">Corner Tiling without Tiling Assistant</property>
+        <property name="title" translatable="yes" comments="Translators: This is a header for a preference group in the 'Keybindings' tab to tile windows to quarters without spawning a Tiling Popup">Corner Tiling without Tiling Assistant</property>
         <property name="visible"
                   bind-source="enable_advanced_experimental_features"
                   bind-property="active"
                   bind-flags="sync-create"/>
         <child>
           <object class="ShortcutListener" id="tile_topleft_quarter_ignore_ta">
-            <property name="title" translatable="yes">Tile to top-left</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Corner Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the top left quarter without spawning a Tiling Popup">Tile to top-left</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="tile_topright_quarter_ignore_ta">
-            <property name="title" translatable="yes">Tile to top-right</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Corner Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the top right quarter without spawning a Tiling Popup">Tile to top-right</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="tile_bottomleft_quarter_ignore_ta">
-            <property name="title" translatable="yes">Tile to bottom-left</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Corner Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the bottom left quarter without spawning a Tiling Popup">Tile to bottom-left</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="tile_bottomright_quarter_ignore_ta">
-            <property name="title" translatable="yes">Tile to bottom-right</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Corner Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the bottom right quarter without spawning a Tiling Popup">Tile to bottom-right</property>
           </object>
         </child>
       </object>
@@ -815,19 +815,19 @@
     <!-- ======================================================================================== -->
     <child>
       <object class="AdwPreferencesGroup">
-        <property name="title" translatable="yes">Debugging</property>
+        <property name="title" translatable="yes" comments="Translators: This is a header for a preference group in the 'Keybindings' tab for some keybindings for debugging">Debugging</property>
         <property name="visible"
                   bind-source="enable_advanced_experimental_features"
                   bind-property="active"
                   bind-flags="sync-create"/>
         <child>
           <object class="ShortcutListener" id="debugging_show_tiled_rects">
-            <property name="title" translatable="yes">Show Tiled Rects</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Debugging' preference group in the 'Keybindings' tab to visibly show the tiled windows rectangles">Show Tiled Rects</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="debugging_free_rects">
-            <property name="title" translatable="yes">Show Free Screen Rects</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'Debugging' preference group in the 'Keybindings' tab to visibly show the area of the tiles without windows">Show Free Screen Rects</property>
           </object>
         </child>
       </object>
@@ -838,7 +838,7 @@
   <!-- = Page: Layouts ======================================================================== -->
   <!-- ======================================================================================== -->
   <object class="AdwPreferencesPage" id="layouts">
-    <property name="title" translatable="yes">Layouts</property>
+    <property name="title" translatable="yes" comments="Translators: This is the name of a tab in the prefs window to configure tiling presets ('Layouts')">Layouts</property>
     <property name="icon-name">video-joined-displays-symbolic</property>
     <property name="visible"
               bind-source="enable_advanced_experimental_features"
@@ -849,16 +849,16 @@
     <!-- ======================================================================================== -->
     <child>
       <object class="AdwPreferencesGroup">
-        <property name="title" translatable="yes">General</property>
+        <property name="title" translatable="yes" comments="Translators: This is a header for a preference group in the 'Layouts' tab">General</property>
         <child>
           <object class="AdwSwitchRow" id="show_layout_panel_indicator">
-            <property name="title" translatable="yes">Panel Indicator</property>
+            <property name="title" translatable="yes" comments="Translators: This is a setting in the 'General' preference group in the 'Layouts' tab to enable an icon in the top panel with some settings for the layouts">Panel Indicator</property>
           </object>
         </child>
         <child>
           <object class="ShortcutListener" id="search_popup_layout">
-            <property name="title" translatable="yes">Search for a Layout</property>
-            <property name="subtitle" translatable="yes">Open a popup listing all the available layouts</property>
+            <property name="title" translatable="yes" comments="Translators: This is a keybinding in the 'General' preference group in the 'Layouts' tab to show a popup with a list of the defined layouts">Search for a Layout</property>
+            <property name="subtitle" translatable="yes" comments="Translators: This is the explanation for the keybinding 'Search for a Layout' in the 'General' preference group in the 'Layouts' tab">Open a popup listing all the available layouts</property>
           </object>
         </child>
       </object>
@@ -868,7 +868,7 @@
     <!-- ======================================================================================== -->
     <child>
       <object class="AdwPreferencesGroup">
-        <property name="title" translatable="yes">Layouts</property>
+        <property name="title" translatable="yes" comments="Translators: This is a header for a preference group in the 'Layouts' tab where user can define layouts (tiling presets)">Layouts</property>
         <child>
           <object class="GtkListBox" id="layouts_listbox">
             <property name="selection-mode">none</property>
@@ -892,21 +892,21 @@
               <object class="GtkButton" id="add_layout_button">
                 <property name="width-request">100</property>
                 <property name="icon-name">list-add-symbolic</property>
-                <property name="tooltip-text" translatable="yes">Add a new Layout.</property>
+                <property name="tooltip-text" translatable="yes" comments="Translators: This is a tooltip for a button that defines a new tiling preset (layout) in the 'Layouts' tab">Add a new Layout.</property>
               </object>
             </child>
             <child>
               <object class="GtkButton" id="save_layouts_button">
                 <property name="width-request">100</property>
                 <property name="icon-name">media-floppy-symbolic</property>
-                <property name="tooltip-text" translatable="yes">Save the layouts to the disk. Invalid changes will be lost!</property>
+                <property name="tooltip-text" translatable="yes" comments="Translators: This is a tooltip for a button that saves the changes to the defined tiling presets (layouts) in the 'Layouts' tab">Save the layouts to the disk. Invalid changes will be lost!</property>
               </object>
             </child>
             <child>
               <object class="GtkButton" id="reload_layouts_button">
                 <property name="width-request">100</property>
                 <property name="icon-name">edit-undo-symbolic</property>
-                <property name="tooltip-text" translatable="yes">Reload the layouts from the disk - discarding all non-saved changes.</property>
+                <property name="tooltip-text" translatable="yes" comments="Translators: This is a tooltip for a button that reloads the the layouts from the disks in the 'Layouts' tab">Reload the layouts from the disk - discarding all non-saved changes.</property>
               </object>
             </child>
             <style>
@@ -963,8 +963,8 @@
               <object class="AdwPreferencesGroup">
                 <child>
                   <object class="AdwSwitchRow" id="enable_advanced_experimental_features">
-                    <property name="title" translatable="yes">Advanced / Experimental Settings</property>
-                    <property name="subtitle" translatable="yes">Show more settings in the main preference window</property>
+                    <property name="title" translatable="yes" comments="Translators: This is the setting to toggle the visibility of advanced/experimental settings in the preference window that can be enabled via the headerbar popup menu">Advanced / Experimental Settings</property>
+                    <property name="subtitle" translatable="yes" comments="Translators: This is the explanation for the 'Advanced / Experimental Settings' setting in the preference window that can be enabled via the headerbar popup menu">Show more settings in the main preference window</property>
                   </object>
                 </child>
               </object>


### PR DESCRIPTION
I am not sure, if there are some conventions when it comes to translator comments or how detailed they should be... but at minimum the comments now provide the location of the untranslated text (not the code location but the location from a user's perspective).