### PR TITLE
MoveHandler: Ignore unused mods for determining the MoveModes

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -327,7 +327,7 @@ export default class TilingMoveHandler {
         const adaptiveMod = Settings.getInt('move-adaptive-tiling-mod');
         const favMod = Settings.getInt('move-favorite-layout-mod');
         const ignoreTAMod = Settings.getInt('ignore-ta-mod');
-        const noMod = pressed.every(modPressed => !modPressed);
+        const noMod = !pressed[adaptiveMod] && !pressed[ignoreTAMod] && !pressed[ignoreTAMod];
 
         const useAdaptiveTiling = defaultMode !== MoveModes.ADAPTIVE_TILING && adaptiveMod && pressed[adaptiveMod] ||
             noMod && defaultMode === MoveModes.ADAPTIVE_TILING;

--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -329,11 +329,11 @@ export default class TilingMoveHandler {
         const ignoreTAMod = Settings.getInt('ignore-ta-mod');
         const noMod = !pressed[adaptiveMod] && !pressed[ignoreTAMod] && !pressed[ignoreTAMod];
 
-        const useAdaptiveTiling = defaultMode !== MoveModes.ADAPTIVE_TILING && adaptiveMod && pressed[adaptiveMod] ||
+        const useAdaptiveTiling = defaultMode !== MoveModes.ADAPTIVE_TILING && pressed[adaptiveMod] ||
             noMod && defaultMode === MoveModes.ADAPTIVE_TILING;
-        const usefavLayout = defaultMode !== MoveModes.FAVORITE_LAYOUT && favMod && pressed[favMod] ||
+        const usefavLayout = defaultMode !== MoveModes.FAVORITE_LAYOUT && pressed[favMod] ||
             noMod && defaultMode === MoveModes.FAVORITE_LAYOUT;
-        const useIgnoreTa = defaultMode !== MoveModes.IGNORE_TA && ignoreTAMod && pressed[ignoreTAMod] ||
+        const useIgnoreTa = defaultMode !== MoveModes.IGNORE_TA && pressed[ignoreTAMod] ||
             noMod && defaultMode === MoveModes.IGNORE_TA;
 
         let newMode = '';


### PR DESCRIPTION
> The default move mode is activated when no modifer key is pressed. That may be to restrictive however because the `Super` key is used when the user wants a window to span multiple tiles. So instead now fallback to the default move mode, only if used modifier keys aren't pressed.
>
> Fixes https://github.com/Leleat/Tiling-Assistant/issues/339