### PR TITLE
Misc: Ignore error that file exists when creating it

### DIFF
--- a/tiling-assistant@leleat-on-github/extension.js
+++ b/tiling-assistant@leleat-on-github/extension.js
@@ -305,7 +305,9 @@ export default class TilingAssistantExtension extends Extension {
         try {
             parent.make_directory_with_parents(null);
         } catch (e) {
-            logError(e);
+            if (e.code !== Gio.IOErrorEnum.EXISTS) {
+                throw e;
+            }
         }
 
         const path = GLib.build_filenamev([parentPath, '/tiledSessionRestore.json']);
@@ -314,7 +316,9 @@ export default class TilingAssistantExtension extends Extension {
         try {
             file.create(Gio.FileCreateFlags.NONE, null);
         } catch (e) {
-            logError(e);
+            if (e.code !== Gio.IOErrorEnum.EXISTS) {
+                throw e;
+            }
         }
 
         file.replace_contents(JSON.stringify(saveObj), null, false,
@@ -340,7 +344,9 @@ export default class TilingAssistantExtension extends Extension {
         try {
             file.create(Gio.FileCreateFlags.NONE, null);
         } catch (e) {
-            logError(e);
+            if (e.code !== Gio.IOErrorEnum.EXISTS) {
+                throw e;
+            }
         }
 
         const [success, contents] = file.load_contents(null);

--- a/tiling-assistant@leleat-on-github/src/prefs/layoutsPrefs.js
+++ b/tiling-assistant@leleat-on-github/src/prefs/layoutsPrefs.js
@@ -169,7 +169,9 @@ export default class {
         try {
             parentDir.make_directory_with_parents(null);
         } catch (e) {
-            logError(e);
+            if (e.code !== Gio.IOErrorEnum.EXISTS) {
+                throw e;
+            }
         }
 
         // Create file, if it doesn't exist.
@@ -180,7 +182,9 @@ export default class {
         try {
             file.create(Gio.FileCreateFlags.NONE, null);
         } catch (e) {
-            logError(e);
+            if (e.code !== Gio.IOErrorEnum.EXISTS) {
+                throw e;
+            }
         }
 
         return file;


### PR DESCRIPTION
Those files existing is expected at all times after the initial creation.
As a result, journal continued being spammed with errors like:

    Gio.IOErrorEnum: Error creating directory ~/.config/tiling-assistant: File exists
    Gio.IOErrorEnum: Error opening file “~/.config/tiling-assistant/tiledSessionRestore.json”: File exists

The logging was only added in 50a1757d17e94bfe787d1f3aced2572fa26ae43a to appease ESLint,
so let’s add more specific `catch` body instead.
