### PR TITLE
keybindingHandler: maximize vertically/horizontally without gaps

### DIFF
--- a/.github/ignore-words.txt
+++ b/.github/ignore-words.txt
@@ -1,5 +1,7 @@
 allws
 Distro
+finalX
+finalY
 fullscreen
 gettext
 Journalctl

--- a/tiling-assistant@leleat-on-github/src/extension/keybindingHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/keybindingHandler.js
@@ -102,10 +102,23 @@ export default class TilingKeybindingHandler {
                     Twm.untile(window);
                 }
 
-            // Maximize vertically even if the height may already be equal to the workArea
-            // e. g. via double-click titlebar, maximize-window-button or whatever
-            } else {
+            // is tiled normally
+            } else if (window.untiledRect) {
                 const tileRect = new Rect(currRect.x, workArea.y, currRect.width, workArea.height);
+                Twm.tile(window, tileRect);
+
+            // is floating
+            } else {
+                const width = Math.min(
+                    currRect.width + Settings.getInt('window-gap'),
+                    workArea.width
+                );
+                const constrainX = Math.max(
+                    currRect.x - Settings.getInt('window-gap') / 2,
+                    workArea.x
+                );
+                const finalX = Math.min(constrainX, workArea.x2 - width);
+                const tileRect = new Rect(finalX, workArea.y, width, workArea.height);
                 Twm.tile(window, tileRect);
             }
 
@@ -125,10 +138,23 @@ export default class TilingKeybindingHandler {
                     Twm.untile(window);
                 }
 
-            // Maximize horizontally even if the width may already be equal to the workArea
-            // e. g. via double-click titlebar, maximize-window-button or whatever
-            } else {
+            // is tiled normally
+            } else if (window.untiledRect) {
                 const tileRect = new Rect(workArea.x, currRect.y, workArea.width, currRect.height);
+                Twm.tile(window, tileRect);
+
+            // is floating
+            } else {
+                const height = Math.min(
+                    currRect.height + Settings.getInt('window-gap'),
+                    workArea.height
+                );
+                const constrainY = Math.max(
+                    currRect.y - Settings.getInt('window-gap') / 2,
+                    workArea.y
+                );
+                const finalY = Math.min(constrainY, workArea.y2 - height);
+                const tileRect = new Rect(workArea.x, finalY, workArea.width, height);
                 Twm.tile(window, tileRect);
             }
 


### PR DESCRIPTION
When maximizing a window vertically or horizontally, we've added gaps to the window like we normally do to tiled windows. This makes sense if the window is already tiled. If the window is floating, we shouldn't add gaps to it and instead should keep the currently visible size.

Fixes https://github.com/Leleat/Tiling-Assistant/issues/349