### PR TITLE
fix: save state on un/tiling instead of session lock/unlock

### DIFF
--- a/tiling-assistant@leleat-on-github/extension.js
+++ b/tiling-assistant@leleat-on-github/extension.js
@@ -281,9 +281,8 @@ export default class TilingAssistantExtension extends Extension {
         try {
             parent.make_directory_with_parents(null);
         } catch (e) {
-            if (e.code !== Gio.IOErrorEnum.EXISTS) {
+            if (e.code !== Gio.IOErrorEnum.EXISTS)
                 throw e;
-            }
         }
 
         const path = GLib.build_filenamev([parentPath, '/tiledSessionRestore2.json']);
@@ -292,9 +291,8 @@ export default class TilingAssistantExtension extends Extension {
         try {
             file.create(Gio.FileCreateFlags.NONE, null);
         } catch (e) {
-            if (e.code !== Gio.IOErrorEnum.EXISTS) {
+            if (e.code !== Gio.IOErrorEnum.EXISTS)
                 throw e;
-            }
         }
 
         file.replace_contents(
@@ -328,9 +326,8 @@ export default class TilingAssistantExtension extends Extension {
         try {
             file.create(Gio.FileCreateFlags.NONE, null);
         } catch (e) {
-            if (e.code !== Gio.IOErrorEnum.EXISTS) {
+            if (e.code !== Gio.IOErrorEnum.EXISTS)
                 throw e;
-            }
         }
 
         const [success, contents] = file.load_contents(null);

--- a/tiling-assistant@leleat-on-github/src/extension/resizeHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/resizeHandler.js
@@ -352,6 +352,8 @@ export default class TilingResizeHandler {
             newGrabbedTiledRectHeight
         );
 
+        Twm.saveTileState(window);
+
         // Now calculate the new tiledRects for the windows, which were resized
         // along the window based on the diff of the window's tiledRect pre
         // and after the grab.
@@ -379,6 +381,8 @@ export default class TilingResizeHandler {
                 win.tiledRect.y += isResizingS ? tiledRectDiffHeight : 0;
                 win.tiledRect.height -= tiledRectDiffHeight;
             }
+
+            Twm.saveTileState(win);
         });
 
         this._preGrabRects.clear();


### PR DESCRIPTION
While I don't know why if it's expected that my extension crashes GNOME Shell when trying to access some window props during a screen lock or if it's a bug in mutter... but either way. This should workaround the crash.

Fixes: https://github.com/Leleat/Tiling-Assistant/issues/267