### PR TITLE
feat: update metadata.json for GNOME 47

### DIFF
--- a/tiling-assistant@leleat-on-github/metadata.json
+++ b/tiling-assistant@leleat-on-github/metadata.json
@@ -2,8 +2,7 @@
   "description": "Expand GNOME's 2 column tiling and add a Windows-snap-assist-inspired popup...",
   "name": "Tiling Assistant",
   "shell-version": [
-    "45",
-    "46"
+    "47"
   ],
   "url": "https://github.com/Leleat/Tiling-Assistant",
   "uuid": "tiling-assistant@leleat-on-github",


### PR DESCRIPTION
From testing in a VM (Fedora Rawhide) with GNOME Shell 47.alpha, it appears the extension is working just fine. So just update metadata.json.

Also drop support for GNOME 45 and 46 from metadata.json since I plan to merge some MRs that are incompatible with (semantic) versioning for older releases. I will instead create branches for the older versions and cherry-pick bug fixes.