### PR TITLE
Disable anims for tiled windows

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
@@ -169,7 +169,9 @@ export class TilingWindowManager {
         if (!window || window.is_skip_taskbar())
             return;
 
+        const wasTiled = window.isTiled;
         const wasMaximized = window.get_maximized();
+
         if (wasMaximized)
             window.unmaximize(wasMaximized);
 
@@ -219,7 +221,12 @@ export class TilingWindowManager {
 
         // Animations
         const wActor = window.get_compositor_private();
-        if (Settings.getBoolean('enable-tile-animations') && wActor && !skipAnim) {
+        if (
+            Settings.getBoolean('enable-tile-animations') &&
+            wActor &&
+            !wasTiled &&
+            !skipAnim
+        ) {
             wActor.remove_all_transitions();
             // HACK => journalctl: 'error in size change accounting'...?
             // TODO: no animation if going from maximized -> tiled and back to back multiple times?


### PR DESCRIPTION
This is only a workaround for the linked issue below. Currently, retiling a tiled window via the Tiling Popup may freeze the window (see the issue for more details on the STR). A better way to fix this would be to implement custom animations for tiling (instead of misusing GNOME's existing solution).

related: https://github.com/Leleat/Tiling-Assistant/issues/376