### PR TITLE
ignore move op for unresizable and skip_taskbar windows

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -120,6 +120,9 @@ export default class TilingMoveHandler {
     }
 
     _onMoveStarted(window, grabOp) {
+        if (!window.allows_resize() || window.is_skip_taskbar())
+            return;
+
         // Also work with a window, which was maximized by GNOME natively
         // because it may have been tiled with this extension before being
         // maximized so we need to restore its size to pre-tiling.


### PR DESCRIPTION
So far, we've ignored skip-taskbar windows when trying to tile them (in TilingWindowManager.tile). The reason is that those windows probably shouldn't be allowed to be tiled, as they are usually stuff like modal dialogs etc. But at the moment we do show the tile preview for those windows, which gives the impression that we allow them to be tiled.

I guess, we could allow skip-taskbar windows to be tiled (as long as they are resizable) but I think there may be more issues with them, e. g. when using modal dialogs that the parent window may be tiled but the dialog not. So I think it's better to just ignore them for now. attach-modal-dialogs settings is relevant to this issue.

Closes https://github.com/Leleat/Tiling-Assistant/issues/387