### PR TITLE
fix: don't ignore unresizable windows during DND

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -120,7 +120,7 @@ export default class TilingMoveHandler {
     }
 
     _onMoveStarted(window, grabOp) {
-        if (!window.allows_resize() || window.is_skip_taskbar())
+        if (window.is_skip_taskbar())
             return;
 
         // Also work with a window, which was maximized by GNOME natively


### PR DESCRIPTION
This partially reverts https://github.com/Leleat/Tiling-Assistant/commit/d960eed6bdf162000c15b1141fa9fb5cf5da283c. That commit added a check to ensure that
unresizable and skip_taskbar windows are ignored during drag and drop
operations to fix https://github.com/Leleat/Tiling-Assistant/issues/387, which was about the tile preview being shown
for windows that can't be tiled.

This doesn't work. "real" maximized windows don't allow resizing. So if
a window was maximized at the start of the DND operation we skipped the
whole tiling code. So let's only ignore skip_taskbar windows. This means
actually unresizable windows may trigger the tile preview (https://github.com/Leleat/Tiling-Assistant/issues/387), but
that is better than skipping the whole DND code for maximized windows,
which is more common than a user trying to tile an unresizable window.
We need to fix the original issue in a different way.

Fixes https://github.com/Leleat/Tiling-Assistant/issues/400