### PR TITLE
extension: Add initial compatbility for GNOME 49

### DIFF
--- a/tiling-assistant@leleat-on-github/metadata.json
+++ b/tiling-assistant@leleat-on-github/metadata.json
@@ -2,7 +2,8 @@
   "description": "Expand GNOME's 2 column tiling and add a Windows-snap-assist-inspired popup...",
   "name": "Tiling Assistant",
   "shell-version": [
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/Leleat/Tiling-Assistant",
   "uuid": "tiling-assistant@leleat-on-github",

--- a/tiling-assistant@leleat-on-github/src/extension/focusHint.js
+++ b/tiling-assistant@leleat-on-github/src/extension/focusHint.js
@@ -295,7 +295,7 @@ class Hint {
 
         if (
             window.is_fullscreen() ||
-            window.get_maximized() === Meta.MaximizeFlags.BOTH
+            (window.maximizedHorizontally && window.maximizedVertically)
         )
             return false;
 
@@ -703,7 +703,7 @@ class StaticOutlineHint extends AnimatedOutlineHint {
 
         if (
             this._window.is_fullscreen() ||
-            this._window.get_maximized() === Meta.MaximizeFlags.BOTH
+            (this._window.maximizedHorizontally && this._window.maximizedVertically)
         )
             this._outline.hide();
         else

--- a/tiling-assistant@leleat-on-github/src/extension/keybindingHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/keybindingHandler.js
@@ -162,8 +162,10 @@ export default class TilingKeybindingHandler {
         } else if (shortcutName === 'restore-window') {
             if (window.untiledRect) // Tiled & maximized with gaps
                 Twm.untile(window, { clampToWorkspace: true });
-            else if (window.get_maximized())
+            else if (window.get_maximized?.())
                 window.unmaximize(window.get_maximized());
+            else if (window.maximizedHorizontally || window.maximizedVertically)
+                window.unmaximize();
 
         // Center window
         } else if (shortcutName === 'center-window') {

--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -126,7 +126,7 @@ export default class TilingMoveHandler {
         // Also work with a window, which was maximized by GNOME natively
         // because it may have been tiled with this extension before being
         // maximized so we need to restore its size to pre-tiling.
-        this._wasMaximizedOnStart = window.get_maximized();
+        this._wasMaximizedOnStart = window.maximizedHorizontally || window.maximizedVertically;
         const [x, y] = global.get_pointer();
 
         // Try to restore the window size


### PR DESCRIPTION
Mutter windows maximization API changed [1], and now it's not possible to perform partial maximizations, I feel that this is affecting the extension (let's discuss that upstream in case), but still we can have something working meanwhile by using the new API.

[1] https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/4415