### PR TITLE
Fix window positioning issue when tiling maximized windows from popup

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/tilingPopup.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingPopup.js
@@ -285,14 +285,14 @@ export const TilingSwitcherPopup = GObject.registerClass({
         const activeWs = global.workspace_manager.get_active_workspace();
         const needsWorkspaceChange = window.get_workspace() !== activeWs;
         const wasMaximized = window.maximizedHorizontally || window.maximizedVertically;
-        
+
         if (needsWorkspaceChange)
             window.change_workspace(activeWs);
 
         // Clear the tiling signals before so that the old tile group
         // won't be accidentally raised.
         Twm.clearTilingProps(window.get_id());
-        
+
         // Calculate the target rect
         let rect = this._freeScreenRect;
         if (isShiftPressed || isAltPressed) {
@@ -303,14 +303,14 @@ export const TilingSwitcherPopup = GObject.registerClass({
             const idx = isShiftPressed ? 0 : 1;
             rect = rect.getUnitAt(idx, rect[size] / 2, orientation);
         }
-        
+
         // Helper to verify and correct window position after tiling.
         // When tiling a maximized window, it sometimes gets sized correctly
         // but positioned incorrectly. This fixes that issue.
         const setupPositionCorrection = () => {
             let sizeChangedId = null;
             let timeoutId = null;
-            
+
             const checkAndFixPosition = () => {
                 if (sizeChangedId) {
                     window.disconnect(sizeChangedId);
@@ -320,25 +320,24 @@ export const TilingSwitcherPopup = GObject.registerClass({
                     GLib.Source.remove(timeoutId);
                     timeoutId = null;
                 }
-                
+
                 const currentRect = window.get_frame_rect();
-                if (currentRect.x !== rect.x || currentRect.y !== rect.y) {
+                if (currentRect.x !== rect.x || currentRect.y !== rect.y)
                     window.move_frame(true, rect.x, rect.y);
-                }
             };
-            
+
             // Listen for size-changed signal
             sizeChangedId = window.connect('size-changed', () => {
                 checkAndFixPosition();
             });
-            
+
             // Fallback timeout in case signal doesn't fire
             timeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, () => {
                 checkAndFixPosition();
                 return GLib.SOURCE_REMOVE;
             });
         };
-        
+
         // When a window is maximized or changing workspaces, wait briefly
         // before tiling to allow the state transition to complete.
         if (needsWorkspaceChange || wasMaximized) {


### PR DESCRIPTION
When a maximized window is selected from the tiling popup, it would be
resized correctly but positioned in the center of the screen instead of
the intended edge location. This occurred both when windows were on the
same workspace and across different workspaces.

The issue is caused by a timing problem when the tile() function
unmaximizes a window - the window actor's position isn't updated before
move_resize_frame() tries to position it.

Solution:
- Detect when a window is maximized or changing workspaces
- Add a brief delay (100ms) before tiling to allow state transitions
- After tiling, verify the window position using the size-changed signal
- Correct the position if needed using move_frame()
- Include a 200ms fallback timeout in case the signal doesn't fire

This ensures windows are positioned correctly regardless of their initial
state or workspace location.
