### PR TITLE
Allow adaptive tiling in empty and favorite layouts

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -566,7 +566,7 @@ export default class TilingMoveHandler {
      * @param {Meta.Window} window
      * @param {Meta.GrabOp} grabOp
      */
-    _adaptiveTilingPreview(window, grabOp) {
+    _adaptiveTilingPreview(window) {
         const screenRects = this._topTileGroup.length
             ? this._topTileGroup.map(w => w.tiledRect).concat(this._freeScreenRects)
             : this._freeScreenRects;
@@ -801,7 +801,6 @@ export default class TilingMoveHandler {
                     this._tileRect = rect.union(this._anchorRect);
                 } else {
                     // Check if we should use adaptive tiling behavior (split the rect)
-                    const edgeRadius = 50;
                     const atTop = this._lastPointerPos.y < rect.y + rect.height * .25;
                     const atBottom = this._lastPointerPos.y > rect.y + rect.height * .75;
                     const atRight = this._lastPointerPos.x > rect.x + rect.width * .75;

--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -567,14 +567,9 @@ export default class TilingMoveHandler {
      * @param {Meta.GrabOp} grabOp
      */
     _adaptiveTilingPreview(window, grabOp) {
-        if (!this._topTileGroup.length) {
-            this._edgeTilingPreview(window, grabOp);
-            return;
-        }
-
-        const screenRects = this._topTileGroup
-            .map(w => w.tiledRect)
-            .concat(this._freeScreenRects);
+        const screenRects = this._topTileGroup.length
+            ? this._topTileGroup.map(w => w.tiledRect).concat(this._freeScreenRects)
+            : this._freeScreenRects;
         const hoveredRect = screenRects.find(r => r.containsPoint(this._lastPointerPos));
         if (!hoveredRect) {
             this._tilePreview.close();
@@ -805,7 +800,23 @@ export default class TilingMoveHandler {
                     this._anchorRect = this._anchorRect ?? rect;
                     this._tileRect = rect.union(this._anchorRect);
                 } else {
-                    this._tileRect = rect.copy();
+                    // Check if we should use adaptive tiling behavior (split the rect)
+                    const edgeRadius = 50;
+                    const atTop = this._lastPointerPos.y < rect.y + rect.height * .25;
+                    const atBottom = this._lastPointerPos.y > rect.y + rect.height * .75;
+                    const atRight = this._lastPointerPos.x > rect.x + rect.width * .75;
+                    const atLeft = this._lastPointerPos.x < rect.x + rect.width * .25;
+                    const splitVertically = atTop || atBottom;
+                    const splitHorizontally = atLeft || atRight;
+
+                    if (splitHorizontally || splitVertically) {
+                        const idx = atTop && !atRight || atLeft ? 0 : 1;
+                        const size = splitHorizontally ? rect.width : rect.height;
+                        const orientation = splitHorizontally ? Orientation.V : Orientation.H;
+                        this._tileRect = rect.getUnitAt(idx, size / 2, orientation);
+                    } else {
+                        this._tileRect = rect.copy();
+                    }
                     this._anchorRect = null;
                 }
 
@@ -816,6 +827,18 @@ export default class TilingMoveHandler {
                     height: this._tileRect.height,
                     opacity: 200
                 });
+
+                // Handle splitting of existing tiled window in favorite rect if applicable
+                this._splitRects.clear();
+                const hoveredWindow = this._topTileGroup.find(w => {
+                    return w.tiledRect.containsPoint(this._lastPointerPos);
+                });
+                if (hoveredWindow && !hoveredWindow.tiledRect.equal(this._tileRect)) {
+                    const splitRect = hoveredWindow.tiledRect.minus(this._tileRect)[0];
+                    if (splitRect)
+                        this._splitRects.set(hoveredWindow, splitRect);
+                }
+
                 return;
             }
         }


### PR DESCRIPTION
Closes [Leleat/Tiling-Assistant#426](https://github.com/Leleat/Tiling-Assistant/issues/426).

Enables adaptive tiling when no windows are tiled and adds adaptive split behavior to favorite layouts, matching adaptive tiling mode.