### PR TITLE
fix: Handle window drag by touch input

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -18,6 +18,18 @@ export default class TilingMoveHandler {
     constructor() {
         const moveOps = [Meta.GrabOp.MOVING, Meta.GrabOp.KEYBOARD_MOVING];
 
+        this._lastSprite = null;
+        global.stage.connectObject(
+            'captured-event',
+            (actor, event) => {
+                /* heuristic: the Clutter.Sprite that initiates the drag is
+                 * the last one getting a stage leave event */
+                if (event.type() === Clutter.EventType.LEAVE)
+                    this._lastSprite = actor.get_context().get_backend().get_sprite?.(global.stage, event);
+            },
+            this
+        );
+
         global.display.connectObject(
             'grab-op-begin',
             (src, window, grabOp) => {
@@ -88,6 +100,7 @@ export default class TilingMoveHandler {
         this._wmPrefs = null;
 
         global.display.disconnectObject(this);
+        global.stage.dicconnectObject(this);
 
         this._tilePreview.destroy();
 
@@ -119,6 +132,13 @@ export default class TilingMoveHandler {
             this._preparePreviewModeChange(this._currPreviewMode, window);
     }
 
+    getDragCoords() {
+        const coords = this._dragSprite?.get_coords?.();
+        if (coords)
+            return [coords.x, coords.y];
+        return global.get_pointer().slice(0, 2);
+    }
+
     _onMoveStarted(window, grabOp) {
         if (window.is_skip_taskbar())
             return;
@@ -127,7 +147,9 @@ export default class TilingMoveHandler {
         // because it may have been tiled with this extension before being
         // maximized so we need to restore its size to pre-tiling.
         this._wasMaximizedOnStart = window.maximizedHorizontally || window.maximizedVertically;
-        const [x, y] = global.get_pointer();
+
+        this._dragSprite = this._lastSprite;
+        const [x, y] = this.getDragCoords();
 
         // Try to restore the window size
         if (window.tiledRect || this._wasMaximizedOnStart) {
@@ -146,7 +168,7 @@ export default class TilingMoveHandler {
                     return GLib.SOURCE_REMOVE;
                 }
 
-                const [currX, currY] = global.get_pointer();
+                const [currX, currY] = this.getDragCoords();
                 const currPoint = { x: currX, y: currY };
                 const oldPoint = { x, y };
                 const moveDist = Util.getDistance(currPoint, oldPoint);
@@ -224,7 +246,7 @@ export default class TilingMoveHandler {
                 let isCtrlReplacement = false;
                 const ctrlReplacedTileGroup = [];
                 const topTileGroup = Twm.getTopTileGroup({ skipTopWindow: true });
-                const pointerPos = { x: global.get_pointer()[0], y: global.get_pointer()[1] };
+                const pointerPos = { x: this.getDragCoords()[0], y: this.getDragCoords()[1] };
                 const twHovered = topTileGroup.some(w => w.tiledRect.containsPoint(pointerPos));
                 if (this._currPreviewMode === MoveModes.ADAPTIVE_TILING && !this._splitRects.size && twHovered) {
                     isCtrlReplacement = true;
@@ -248,6 +270,8 @@ export default class TilingMoveHandler {
                 // of a different tile group, with ctrl-(super)-drag. The window may
                 // be maximized by ctrl-super-drag.
                 isCtrlReplacement && window.isTiled && Twm.updateTileGroup(ctrlReplacedTileGroup);
+
+                this._dragSprite = null;
             }
         } finally {
             if (this._posChangedId) {
@@ -277,7 +301,7 @@ export default class TilingMoveHandler {
     // Without the lowPerfMode enabled this will be called whenever the window is
     // moved (by listening to the position-changed signal)
     _onMoving(grabOp, window, lowPerfMode = false) {
-        const [x, y] = global.get_pointer();
+        const [x, y] = this.getDragCoords();
         const currPointerPos = { x, y };
 
         if (lowPerfMode) {


### PR DESCRIPTION
global.get_pointer() does not track touch input, so when initiating a drag via touchscreen we would be incorrectly tracking the mouse position instead.

Unfortunately, in GNOME 50 there is no API to get information on the touch point that is driving the window drag from Display::grab-op-begin. The best we can do is track global events happening before grab-op-begin and try to infer which touch point is driving the drag. Specifically, the global stage receives a LEAVE event from the device starting the window drag immediatly prior to Display::grab-op-begin.

For this implementation we use the Clutter.Sprite API which is new in GNOME 49, and specifically Cluter.Sprite::get_coords() which is new in GNOME 50, but we fall-back to global.get_pointer() to support older shell versions, where however the bug will not be fixed.
