### PR TITLE
moveHandler: Workaround spurious LEAVE events from tablet tools

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/moveHandler.js
@@ -24,8 +24,17 @@ export default class TilingMoveHandler {
             (actor, event) => {
                 /* heuristic: the Clutter.Sprite that initiates the drag is
                  * the last one getting a stage leave event */
-                if (event.type() === Clutter.EventType.LEAVE)
-                    this._lastSprite = actor.get_context().get_backend().get_sprite?.(global.stage, event);
+                if (event.type() === Clutter.EventType.LEAVE &&
+                    event.get_flags() & Clutter.EventFlags.FLAG_GRAB_NOTIFY) {
+                    const sprite = actor.get_context().get_backend().get_sprite?.(global.stage, event);
+
+                    /* workaround spurious leave events from tablet tools */
+                    if (sprite?.role === Clutter.SpriteRole?.POINTER)
+                        this._seenPointerLeave = true;
+
+                    if (sprite?.role !== Clutter.SpriteRole?.TABLET || !this._seenPointerLeave)
+                        this._lastSprite = sprite;
+                }
             },
             this
         );
@@ -148,6 +157,7 @@ export default class TilingMoveHandler {
         // maximized so we need to restore its size to pre-tiling.
         this._wasMaximizedOnStart = window.maximizedHorizontally || window.maximizedVertically;
 
+        this._seenPointerLeave = false;
         this._dragSprite = this._lastSprite;
         const [x, y] = this.getDragCoords();
 


### PR DESCRIPTION
Due to the lack of public APIs for retrieving the Clutter.Sprite associated with a window drag, the TilingMoveHandler implements a heuristic that the drag sprite is the one associated with the latest LEAVE event.

This heuristic was being thrown off by spurious LEAVE events from tablet tools, which are being fired immediatly after the mouse LEAVE event when the drag was initiated by the mouse. This might be related to https://gitlab.gnome.org/GNOME/mutter/-/work_items/4678

Filter these events out to solve the issue.
Also check for Clutter.EventFlags.FLAG_GRAB_NOTIFY for good measure.

Fixes: ad4707d ("fix: Handle window drag by touch input")
Closes: https://github.com/ubuntu/Tiling-Assistant/issues/453