### PR TITLE
metadata.json: Declare support for GNOME 51

### DIFF
--- a/tiling-assistant@leleat-on-github/metadata.json
+++ b/tiling-assistant@leleat-on-github/metadata.json
@@ -4,7 +4,8 @@
   "shell-version": [
     "48",
     "49",
-    "50"
+    "50",
+    "51"
   ],
   "url": "https://github.com/Leleat/Tiling-Assistant",
   "uuid": "tiling-assistant@leleat-on-github",


### PR DESCRIPTION
No breakages noted with 51.alpha