### PR TITLE
Fix GNOME 50 edge/quarter tiling offset toward screen edge (fix of bug #2155749)

### DIFF
--- a/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
+++ b/tiling-assistant@leleat-on-github/src/extension/tilingWindowManager.js
@@ -5,6 +5,8 @@ import { getWindows } from '../dependencies/unexported/altTab.js';
 import { Orientation, Settings } from '../common.js';
 import { Rect, Util } from './utility.js';
 
+const [MajorShellVersion] = Util.getShellVersion();
+
 /**
  * Singleton responsible for tiling. Implement the signals in a separate Clutter
  * class so this doesn't need to be instanced.
@@ -218,7 +220,10 @@ export class TilingWindowManager {
 
         // Animations
         const wActor = window.get_compositor_private();
+        // GNOME 50+: _prepareAnimationInfo(MAXIMIZE) can interact badly with the
+        // placement path below (ubuntu/Tiling-Assistant#454, LP #2155749).
         if (
+            MajorShellVersion < 50 &&
             Settings.getBoolean('enable-tile-animations') &&
             wActor &&
             !wasTiled &&
@@ -235,28 +240,33 @@ export class TilingWindowManager {
             );
         }
 
-        if (verticalMaximize) {
-            if (window.set_maximize_flags)
-                window.set_maximize_flags(Meta.MaximizeFlags.VERTICAL);
-            else
-                window.maximize(Meta.MaximizeFlags.VERTICAL);
-        } else if (horizontalMaximize) {
-            if (window.set_maximize_flags)
-                window.set_maximize_flags(Meta.MaximizeFlags.HORIZONTAL);
-            else
-                window.maximize(Meta.MaximizeFlags.HORIZONTAL);
-        } else if (!maximize && window.override_constraints) {
-            const leftConstraint = newRect.x === workArea.x
-                ? Meta.WindowConstraint.MONITOR : Meta.WindowConstraint.WINDOW;
-            const rightConstraint = newRect.x2 === workArea.x2
-                ? Meta.WindowConstraint.MONITOR : Meta.WindowConstraint.WINDOW;
-            const topConstraint = newRect.y === workArea.y
-                ? Meta.WindowConstraint.MONITOR : Meta.WindowConstraint.WINDOW;
-            const bottomConstraint = newRect.y2 === workArea.y2
-                ? Meta.WindowConstraint.MONITOR : Meta.WindowConstraint.WINDOW;
+        // GNOME 50+: semi-maximize (VERTICAL/HORIZONTAL) before move_resize_frame
+        // causes tiles to be anchored by their center to the screen edge instead
+        // of flush placement (ubuntu/Tiling-Assistant#454, LP #2155749).
+        if (MajorShellVersion < 50) {
+            if (verticalMaximize) {
+                if (window.set_maximize_flags)
+                    window.set_maximize_flags(Meta.MaximizeFlags.VERTICAL);
+                else
+                    window.maximize(Meta.MaximizeFlags.VERTICAL);
+            } else if (horizontalMaximize) {
+                if (window.set_maximize_flags)
+                    window.set_maximize_flags(Meta.MaximizeFlags.HORIZONTAL);
+                else
+                    window.maximize(Meta.MaximizeFlags.HORIZONTAL);
+            } else if (!maximize && window.override_constraints) {
+                const leftConstraint = newRect.x === workArea.x
+                    ? Meta.WindowConstraint.MONITOR : Meta.WindowConstraint.WINDOW;
+                const rightConstraint = newRect.x2 === workArea.x2
+                    ? Meta.WindowConstraint.MONITOR : Meta.WindowConstraint.WINDOW;
+                const topConstraint = newRect.y === workArea.y
+                    ? Meta.WindowConstraint.MONITOR : Meta.WindowConstraint.WINDOW;
+                const bottomConstraint = newRect.y2 === workArea.y2
+                    ? Meta.WindowConstraint.MONITOR : Meta.WindowConstraint.WINDOW;
 
-            window.override_constraints(topConstraint, leftConstraint,
-                rightConstraint, bottomConstraint);
+                window.override_constraints(topConstraint, leftConstraint,
+                    rightConstraint, bottomConstraint);
+            }
         }
 
         // See issue #137.
@@ -273,9 +283,17 @@ export class TilingWindowManager {
         // to workaround that by first only moving the window and then resizing it. That
         // workaround was already necessary under Wayland because of some apps. E. g.
         // first tiling Nautilus and then Firefox using the Tiling Popup.
+        //
+        // GNOME 50+: move_frame + user_op=true interact badly with placement and can
+        // leave half/quarter tiles offset toward the screen edge. Use a single
+        // clamped move_resize_frame instead.
         window.move_to_monitor(monitor);
-        window.move_frame(true, x, y);
-        window.move_resize_frame(true, x, y, width, height);
+        if (MajorShellVersion < 50) {
+            window.move_frame(true, x, y);
+            window.move_resize_frame(true, x, y, width, height);
+        } else {
+            window.move_resize_frame(false, x, y, width, height);
+        }
 
         // Maximized with gaps
         if (maximize) {


### PR DESCRIPTION
## Summary
- On GNOME 50 / Ubuntu 26.04, right-half and quarter tiling places windows with a large horizontal offset (windows appear anchored by their center to the screen edge instead of flush to the work area). See #454 and [LP #2155749](https://bugs.launchpad.net/ubuntu/+source/gnome-shell-ubuntu-extensions/+bug/2155749).
- Skip the GNOME 50-incompatible placement path: do not call `set_maximize_flags(VERTICAL/HORIZONTAL)`, `override_constraints`, `_prepareAnimationInfo(MAXIMIZE)`, or `move_frame` before resize on Shell 50+.
- Place tiled windows with a single clamped `move_resize_frame(false, ...)` on GNOME 50+. Older Shell versions keep the previous behavior.

## Additional info
- Ubuntu / Launchpad bug discussion: https://bugs.launchpad.net/ubuntu/+source/gnome-shell-ubuntu-extensions/+bug/2155749
- Proposed fix PR: https://github.com/ubuntu/Tiling-Assistant/pull/462

## Test plan
- [ ] On Ubuntu 26.04 / GNOME 50 Wayland, enable Ubuntu Tiling Assistant
- [ ] Quarter tiles (corners / numpad): flush to work-area corners
- [ ] Confirm tiling still works after logout/login