### PR TITLE
feat: cycle edge tiles through equal widths

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -14,6 +14,8 @@ jobs:
           node-version: "*"
       - name: Prepare Linters
         run: npm i
+      - name: Run Node tests
+        run: npm test
       - name: Run ESLint (*.js)
         run: >
           git diff --name-only --diff-filter=ACMTUXB origin/${{ github.base_ref }} HEAD |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Add an optional Edge Cycle dynamic keybinding behavior that cycles full-height left/right tiles through half, third, and quarter widths.
+
 ## [54] - 2026-02-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Tiling Assistant is a GNOME Shell extension which adds a Windows-like snap assis
 
 Please visit the [wiki](https://github.com/Leleat/Tiling-Assistant/wiki) for a list of all features. You'll also find videos and explanations for each of them there.
 
+### Edge Cycle
+
+The optional **Edge Cycle** dynamic keybinding behavior cycles a full-height window at the left or right edge through equal half, third, and quarter widths. Repeatedly press the same horizontal tile shortcut to cycle through the states:
+
+```text
+Super+Left:  left half -> left third -> left quarter -> left half
+Super+Right: right half -> right third -> right quarter -> right half
+```
+
+Enable it under **Preferences → General → Dynamic Keybinding Behavior**. Existing dynamic keybinding modes remain unchanged by default.
+
+The existing `tile-maximize-vertically` shortcut can be assigned to `Super+Up` if vertical-only maximization is desired. Clear the `tile-maximize` binding first to avoid a shortcut conflict.
+
 ## Supported GNOME Versions
 
 The [metadata](https://github.com/Leleat/Tiling-Assistant/blob/main/tiling-assistant%40leleat-on-github/metadata.json#L4) file lists all currently supported GNOME Shell versions. Generally, only the most recent GNOME Shell is supported. That means older releases may not include all features and bug fixes. You can look at the revisions of the wiki articles to find out when a feature was added, changed, or improved. The [changelog](https://github.com/Leleat/Tiling-Assistant/blob/main/CHANGELOG.md) will show all changes in chronological order.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "private": true,
     "homepage": "https://github.com/Leleat/Tiling-Assistant",
     "main": "tiling-assistant@leleat-on-github/extension.js",
-    "scripts": {},
+    "scripts": {
+        "test": "node --test test/*.test.js"
+    },
     "author": "Leleat",
     "license": "GPL-2.0-or-later",
     "type": "module",

--- a/test/edgeCycle.test.js
+++ b/test/edgeCycle.test.js
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    DEFAULT_EDGE_DIVISIONS,
+    detectEdgeDivision,
+    isFullHeightEdgeRect,
+    makeEdgeRect,
+    nextDivision
+} from '../tiling-assistant@leleat-on-github/src/extension/edgeCycle.js';
+
+const workArea = { x: 0, y: 0, width: 1200, height: 800 };
+
+test('cycles the default divisions and wraps to the first division', () => {
+    assert.deepEqual(DEFAULT_EDGE_DIVISIONS, [2, 3, 4]);
+    assert.equal(nextDivision(undefined), 2);
+    assert.equal(nextDivision(2), 3);
+    assert.equal(nextDivision(3), 4);
+    assert.equal(nextDivision(4), 2);
+    assert.equal(nextDivision(99), 2);
+});
+
+test('creates equal-width rectangles anchored to the left edge', () => {
+    assert.deepEqual(makeEdgeRect(workArea, 'left', 2), {
+        x: 0,
+        y: 0,
+        width: 600,
+        height: 800
+    });
+    assert.deepEqual(makeEdgeRect(workArea, 'left', 3), {
+        x: 0,
+        y: 0,
+        width: 400,
+        height: 800
+    });
+    assert.deepEqual(makeEdgeRect(workArea, 'left', 4), {
+        x: 0,
+        y: 0,
+        width: 300,
+        height: 800
+    });
+});
+
+test('creates equal-width rectangles anchored to the right edge', () => {
+    assert.deepEqual(makeEdgeRect(workArea, 'right', 2), {
+        x: 600,
+        y: 0,
+        width: 600,
+        height: 800
+    });
+    assert.deepEqual(makeEdgeRect(workArea, 'right', 3), {
+        x: 800,
+        y: 0,
+        width: 400,
+        height: 800
+    });
+    assert.deepEqual(makeEdgeRect(workArea, 'right', 4), {
+        x: 900,
+        y: 0,
+        width: 300,
+        height: 800
+    });
+});
+
+test('keeps the final pixel in the work area for an odd width', () => {
+    const oddWorkArea = { x: -1920, y: 10, width: 1919, height: 1080 };
+    const rects = [2, 3, 4].map(division => makeEdgeRect(oddWorkArea, 'left', division));
+
+    rects.forEach(rect => {
+        assert.equal(rect.x, oddWorkArea.x);
+        assert.equal(rect.y, oddWorkArea.y);
+        assert.equal(rect.height, oddWorkArea.height);
+        assert.ok(rect.width > 0);
+        assert.ok(rect.x + rect.width <= oddWorkArea.x + oddWorkArea.width);
+    });
+
+    const right = makeEdgeRect(oddWorkArea, 'right', 3);
+    assert.equal(right.x + right.width, oddWorkArea.x + oddWorkArea.width);
+});
+
+test('detects only full-height rectangles at the requested edge', () => {
+    const leftThird = makeEdgeRect(workArea, 'left', 3);
+    const rightQuarter = makeEdgeRect(workArea, 'right', 4);
+
+    assert.equal(isFullHeightEdgeRect(leftThird, workArea, 'left'), true);
+    assert.equal(isFullHeightEdgeRect(rightQuarter, workArea, 'right'), true);
+    assert.equal(detectEdgeDivision(leftThird, workArea, 'left'), 3);
+    assert.equal(detectEdgeDivision(rightQuarter, workArea, 'right'), 4);
+    assert.equal(detectEdgeDivision(leftThird, workArea, 'right'), null);
+    assert.equal(detectEdgeDivision({ ...leftThird, y: 10 }, workArea, 'left'), null);
+    assert.equal(detectEdgeDivision({ ...leftThird, height: 798 }, workArea, 'left'), null);
+    assert.equal(detectEdgeDivision({ ...leftThird, x: 20 }, workArea, 'left'), null);
+});
+
+test('allows a small coordinate tolerance when detecting a tile', () => {
+    const leftHalf = makeEdgeRect(workArea, 'left', 2);
+    const shifted = { ...leftHalf, x: 1, y: 1, width: 599, height: 799 };
+
+    assert.equal(detectEdgeDivision(shifted, workArea, 'left'), 2);
+    assert.equal(detectEdgeDivision(shifted, workArea, 'left', [2], 0), null);
+});

--- a/tiling-assistant@leleat-on-github/prefs.js
+++ b/tiling-assistant@leleat-on-github/prefs.js
@@ -166,7 +166,8 @@ export default class Prefs extends ExtensionPreferences {
                     'dynamic_keybinding_window_focus_row',
                     'dynamic_keybinding_tiling_state_row',
                     'dynamic_keybinding_tiling_state_windows_row',
-                    'dynamic_keybinding_favorite_layout_row'
+                    'dynamic_keybinding_favorite_layout_row',
+                    'dynamic_keybinding_edge_cycle_row'
                 ]
             },
             {

--- a/tiling-assistant@leleat-on-github/schemas/org.gnome.shell.extensions.tiling-assistant.gschema.xml
+++ b/tiling-assistant@leleat-on-github/schemas/org.gnome.shell.extensions.tiling-assistant.gschema.xml
@@ -17,7 +17,7 @@
 			<default>false</default>
 		</key>
 		<key name="dynamic-keybinding-behavior" type="i">
-			<!-- 0: Disabled, 1: Focus, 2: Tiling State, 3: Tiling State (Windows), 4: Favorite Layout -->
+			<!-- 0: Disabled, 1: Focus, 2: Tiling State, 3: Tiling State (Windows), 4: Favorite Layout, 5: Edge Cycle -->
 			<default>0</default>
 		</key>
 		<key name="focus-hint" type="i">

--- a/tiling-assistant@leleat-on-github/src/common.js
+++ b/tiling-assistant@leleat-on-github/src/common.js
@@ -152,6 +152,7 @@ export class DynamicKeybindings {
     static TILING_STATE = 2;
     static TILING_STATE_WINDOWS = 3;
     static FAVORITE_LAYOUT = 4;
+    static EDGE_CYCLE = 5;
 }
 
 export const FocusHint = Object.freeze({

--- a/tiling-assistant@leleat-on-github/src/extension/edgeCycle.js
+++ b/tiling-assistant@leleat-on-github/src/extension/edgeCycle.js
@@ -1,0 +1,85 @@
+export const DEFAULT_EDGE_DIVISIONS = Object.freeze([2, 3, 4]);
+
+const SUPPORTED_SIDES = new Set(['left', 'right']);
+
+function isClose(actual, expected, tolerance) {
+    return Math.abs(actual - expected) <= tolerance;
+}
+
+function isValidDivision(division) {
+    return Number.isInteger(division) && division > 0;
+}
+
+function validateDivisions(divisions) {
+    if (!divisions.length || divisions.some(division => !isValidDivision(division)))
+        throw new TypeError('divisions must contain positive integers');
+}
+
+function validateSide(side) {
+    if (!SUPPORTED_SIDES.has(side))
+        throw new TypeError(`Unsupported edge side: ${side}`);
+}
+
+export function nextDivision(currentDivision, divisions = DEFAULT_EDGE_DIVISIONS) {
+    validateDivisions(divisions);
+
+    const currentIndex = divisions.indexOf(currentDivision);
+    return divisions[(currentIndex + 1) % divisions.length];
+}
+
+export function makeEdgeRect(workArea, side, division) {
+    validateSide(side);
+    if (!isValidDivision(division))
+        throw new TypeError('division must be a positive integer');
+
+    const width = Math.floor(workArea.width / division);
+    const x = side === 'left'
+        ? workArea.x
+        : workArea.x + workArea.width - width;
+
+    return {
+        x,
+        y: workArea.y,
+        width,
+        height: workArea.height
+    };
+}
+
+export function isFullHeightEdgeRect(rect, workArea, side, tolerance = 1) {
+    validateSide(side);
+
+    if (!rect || !workArea || tolerance < 0)
+        return false;
+
+    const atLeftEdge = isClose(rect.x, workArea.x, tolerance);
+    const atRightEdge = isClose(
+        rect.x + rect.width,
+        workArea.x + workArea.width,
+        tolerance
+    );
+    const atTopEdge = isClose(rect.y, workArea.y, tolerance);
+    const fullHeight = isClose(rect.height, workArea.height, tolerance);
+
+    return atTopEdge && fullHeight && (side === 'left' ? atLeftEdge : atRightEdge);
+}
+
+export function detectEdgeDivision(
+    rect,
+    workArea,
+    side,
+    divisions = DEFAULT_EDGE_DIVISIONS,
+    tolerance = 1
+) {
+    validateDivisions(divisions);
+
+    if (!isFullHeightEdgeRect(rect, workArea, side, tolerance))
+        return null;
+
+    return divisions.find(division => {
+        const expected = makeEdgeRect(workArea, side, division);
+        return isClose(rect.x, expected.x, tolerance) &&
+            isClose(rect.y, expected.y, tolerance) &&
+            isClose(rect.width, expected.width, tolerance) &&
+            isClose(rect.height, expected.height, tolerance);
+    }) ?? null;
+}

--- a/tiling-assistant@leleat-on-github/src/extension/keybindingHandler.js
+++ b/tiling-assistant@leleat-on-github/src/extension/keybindingHandler.js
@@ -2,6 +2,11 @@ import { Clutter, Meta, Shell, St } from '../dependencies/gi.js';
 import { _, Main } from '../dependencies/shell.js';
 
 import { Direction, DynamicKeybindings, Settings, Shortcuts } from '../common.js';
+import {
+    detectEdgeDivision,
+    makeEdgeRect,
+    nextDivision
+} from './edgeCycle.js';
 import { Rect, Util } from './utility.js';
 import { TilingWindowManager as Twm } from './tilingWindowManager.js';
 
@@ -219,6 +224,13 @@ export default class TilingKeybindingHandler {
             const windowsStyle = DynamicKeybindings.TILING_STATE_WINDOWS;
             const isWindowsStyle = dynamicSetting === windowsStyle;
             const workArea = new Rect(window.get_work_area_current_monitor());
+
+            if (dynamicSetting === DynamicKeybindings.EDGE_CYCLE &&
+                    ['tile-left-half', 'tile-right-half'].includes(shortcutName)) {
+                this._dynamicEdgeCycle(window, shortcutName, workArea);
+                return;
+            }
+
             const rect = Twm.getTileFor(shortcutName, workArea, window.get_monitor());
 
             switch (dynamicSetting) {
@@ -236,6 +248,25 @@ export default class TilingKeybindingHandler {
                     Twm.toggleTiling(window, rect);
             }
         }
+    }
+
+    /**
+     * Cycles a window through equal-width full-height tiles at the selected
+     * screen edge.
+     *
+     * @param {Meta.Window} window a Meta.Window.
+     * @param {string} shortcutName the activated horizontal tile shortcut.
+     * @param {Rect} workArea the work area of the window's current monitor.
+     */
+    _dynamicEdgeCycle(window, shortcutName, workArea) {
+        const side = shortcutName === 'tile-left-half' ? 'left' : 'right';
+        const currentRect = window.tiledRect ?? window.get_frame_rect();
+        const currentDivision = detectEdgeDivision(currentRect, workArea, side);
+        const division = nextDivision(currentDivision);
+        const edgeRect = makeEdgeRect(workArea, side, division);
+        const rect = new Rect(edgeRect.x, edgeRect.y, edgeRect.width, edgeRect.height);
+
+        Twm.tile(window, rect, { openTilingPopup: false });
     }
 
     /**

--- a/tiling-assistant@leleat-on-github/src/ui/prefs.ui
+++ b/tiling-assistant@leleat-on-github/src/ui/prefs.ui
@@ -277,6 +277,18 @@
               </child>
             </object>
           </child>
+          <child>
+            <object class="AdwActionRow" id="dynamic_keybinding_edge_cycle_row">
+              <property name="title" translatable="yes" comments="Translators: This setting is under the 'Dynamic Keybinding Behavior' preference group. It cycles a window at the left or right edge through equal-width columns">Edge Cycle</property>
+              <property name="subtitle" translatable="yes" comments="Translators: This is an explanation for the 'Edge Cycle' option. Repeatedly pressing the same horizontal tile shortcut cycles through half, third, and quarter widths">Cycle a window at the left or right edge through half, third, and quarter widths</property>
+              <property name="activatable-widget">dynamic_keybinding_edge_cycle_button</property>
+              <child type="prefix">
+                <object class="GtkCheckButton" id="dynamic_keybinding_edge_cycle_button">
+                  <property name="group">dynamic_keybinding_disabled_button</property>
+                </object>
+              </child>
+            </object>
+          </child>
         </object>
       </child>
       <!-- ======================================================================================== -->

--- a/translations/main.pot
+++ b/translations/main.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-03 22:14+0100\n"
+"POT-Creation-Date: 2026-08-03 23:20+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,8 +46,8 @@ msgstr ""
 #. Translators: This is a header for a preference group in the 'Keybindings' tab
 #. Translators: This is a header for a preference group in the 'Layouts' tab
 #: tiling-assistant@leleat-on-github/src/ui/prefs.ui:41
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:659
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:880
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:671
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:892
 msgid "General"
 msgstr ""
 
@@ -164,10 +164,10 @@ msgstr ""
 #. Translators: This is a setting for the preference group 'Focus Hint' in the 'General' tab in the prefs window
 #. Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab
 #: tiling-assistant@leleat-on-github/src/ui/prefs.ui:220
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:294
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:522
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:542
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:562
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:306
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:534
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:554
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:574
 #: tiling-assistant@leleat-on-github/src/ui/shortcutListener.ui:14
 #: tiling-assistant@leleat-on-github/src/prefs/shortcutListener.js:102
 msgid "Disabled"
@@ -217,7 +217,7 @@ msgstr ""
 #. Translators: This setting is under the preference group 'Dynamic Keybinding Behavior' in the 'General' tab. It will change some tiling shortcuts to shift the current window along the 'Favorite Layout' instead of the default half/quarter tiling
 #. Translators: This is an option for the preference group 'Default Window Movement Mode' in the 'General' tab. In this mode, windows can only be tiled to tiles in the favorite layout when using the mouse
 #: tiling-assistant@leleat-on-github/src/ui/prefs.ui:266
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:457
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:469
 msgid "Favorite Layout"
 msgstr ""
 
@@ -226,166 +226,178 @@ msgstr ""
 msgid "Move the window along your favorite Layout"
 msgstr ""
 
+#. Translators: This setting is under the 'Dynamic Keybinding Behavior' preference group. It cycles a window at the left or right edge through equal-width columns
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:282
+msgid "Edge Cycle"
+msgstr ""
+
+#. Translators: This is an explanation for the 'Edge Cycle' option. Repeatedly pressing the same horizontal tile shortcut cycles through half, third, and quarter widths
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:283
+msgid ""
+"Cycle a window at the left or right edge through half, third, and quarter "
+"widths"
+msgstr ""
+
 #. Translators: This is a header for a preference group in the 'General' tab for settings to indicate the currently focused window
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:287
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:299
 msgid "Focus Hint"
 msgstr ""
 
 #. Translators: This is the explanation for the setting 'Disabled' for the preference group 'Focus Hint' in the 'General' tab in the prefs window
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:295
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:307
 msgid "Do <i>not</i> indicate the focused window"
 msgstr ""
 
 #. Translators: This is a setting for the preference group 'Focus Hint' in the 'General' tab in the prefs window. This setting will indicate the focused window by animating an outline around the focused window under certain circumstances
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:305
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:317
 msgid "Outline Animation"
 msgstr ""
 
 #. Translators: This is the explanation for the setting 'Outline Animation' for the preference group 'Focus Hint' in the 'General' tab in the prefs window
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:306
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:318
 msgid ""
 "When the focus changes, temporarily outline the focused window. Maximized "
 "and fullscreen windows are exempt from this"
 msgstr ""
 
 #. Translators: This is a setting for the preference group 'Focus Hint' in the 'General' tab in the prefs window. This setting will scale the focused window up to indicate the focus under certain circumstances.
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:317
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:329
 msgid "Upscale Animation"
 msgstr ""
 
 #. Translators: This is the explanation for the setting 'Upscale Animation' for the preference group 'Focus Hint' in the 'General' tab in the prefs window
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:318
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:330
 msgid ""
 "When the focus changes, temporarily scale the focused window up. Maximized "
 "and fullscreen windows are exempt from this"
 msgstr ""
 
 #. Translators: This is a setting for the preference group 'Focus Hint' in the 'General' tab in the prefs window. This setting will outline the focused window (almost) at all times. There is no animation, hence 'static'
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:329
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:341
 msgid "Static Outline"
 msgstr ""
 
 #. Translators: This is the explanation for the setting 'Static Outline' for the preference group 'Focus Hint' in the 'General' tab in the prefs window
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:330
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:342
 msgid ""
 "Indicate the focused window with a static outline unless it's maximized or "
 "in fullscreen."
 msgstr ""
 
 #. Translators: This is the setting for the style of the focus hint in the preference group 'Focus Hint' in the 'General' tab in the prefs window
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:349
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:361
 msgid "Outline Style"
 msgstr ""
 
 #. Translators: This is the explanation for the setting 'Outline Style' for the preference group 'Focus Hint' in the 'General' tab in the prefs window
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:350
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:362
 msgid "'Border' is recommended if you use transparent windows"
 msgstr ""
 
 #. Translators: This is an option for the setting of the style of the focus hint in the preference group 'Focus Hint' in the 'General' tab in the prefs window
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:354
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:366
 msgid "Solid Background"
 msgstr ""
 
 #. Translators: This is an option for the setting of the style of the focus hint in the preference group 'Focus Hint' in the 'General' tab in the prefs window
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:355
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:367
 msgid "Border"
 msgstr ""
 
 #. Translators: This is the setting for the color of the focus hint in the preference group 'Focus Hint' in the 'General' tab in the prefs window
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:363
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:375
 msgid "Outline Color"
 msgstr ""
 
 #. Translators: This is a setting under the 'Focus Hint' preference group in the 'General' tab in the prefs window to set the size of the focus hint
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:374
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:386
 msgid "Outline Size"
 msgstr ""
 
 #. Translators: This is a setting under the 'Focus Hint' preference group in the 'General' tab in the prefs window to set the size of the focus hint border radius
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:387
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:399
 msgid "Outline Border Radius"
 msgstr ""
 
 #. Translators: This is a header for a preference group in the 'General' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:405
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:417
 msgid "Animations"
 msgstr ""
 
 #. Translators: This setting enables tiling animations and is listed under the 'Animation' preference group in the 'General' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:412
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:424
 msgid "Tiling"
 msgstr ""
 
 #. Translators: This setting enables untiling animations and is listed under the 'Animation' preference group in the 'General' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:417
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:429
 msgid "Untiling"
 msgstr ""
 
 #. Translators: This is a header for a preference group in the 'General' tab. See https://github.com/Leleat/Tiling-Assistant/wiki/Window-Grab-Modes for more information
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:427
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:439
 msgid "Default Window Movement Mode"
 msgstr ""
 
 #. Translators: This is the explanation for the preference group 'Default Window Movement Mode' in the 'General' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:428
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:440
 msgid "The movement mode that is activated when no modifier key is pressed"
 msgstr ""
 
 #. Translators: This is an option for the preference group 'Default Window Movement Mode' in the 'General' tab. In this mode, tiling will be activated, when the user drags a window to the screen edges
 #. Translators: This is a header for a preference group in the 'Keybindings' tab to tile windows to the screen halves
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:435
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:726
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:447
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:738
 msgid "Edge Tiling"
 msgstr ""
 
 #. Translators: This is the explanation for the 'Edge Tiling' option in the preference group 'Default Window Movement Mode' in the 'General' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:436
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:448
 msgid ""
 "Moving the window to the screen edges or corners will open the default tile "
 "preview"
 msgstr ""
 
 #. Translators: This is an option for the preference group 'Default Window Movement Mode' in the 'General' tab. In this mode, tiling a window may affect the current visible layout. E. g. A half-screen tile can be split into 2 quarter tiles
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:445
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:457
 msgid "Adaptive Tiling"
 msgstr ""
 
 #. Translators: This is the explanation for the 'Adaptive Tiling' option in the preference group 'Default Window Movement Mode' in the 'General' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:446
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:458
 msgid ""
 "Releasing the grab on a window while hovering over a tile will push the "
 "overlapped window(s) aside"
 msgstr ""
 
 #. Translators: This is the explanation for the 'Favorite Layout' option in the preference group 'Default Window Movement Mode' in the 'General' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:458
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:470
 msgid ""
 "The tile preview will stick to your favorite layout from the 'Layouts' page"
 msgstr ""
 
 #. Translators: This is an option for the preference group 'Default Window Movement Mode' in the 'General' tab. In this mode core features (Tiling Popup and Tile Groups) will be disabled
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:469
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:481
 msgid "Ignore Tiling Assistant"
 msgstr ""
 
 #. Translators: This is the explanation for the 'Ignore Tiling Assistant' option in the preference group 'Default Window Movement Mode' in the 'General' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:470
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:482
 msgid "Use Edge Tiling without Tiling Assistant's features"
 msgstr ""
 
 #. Translators: This is a header for misc settings in the 'General' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:486
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:498
 msgid "Other"
 msgstr ""
 
 #. Translators: This is a setting in the 'Other' preference group in the 'General' tab. When moving a window to a new monitor the tiling preview will stick for a short time (the 'Monitor Switch Grace Period') to the old monitor to make tiling on multi-monitor setups easier
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:489
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:501
 msgid "Monitor Switch Grace Period"
 msgstr ""
 
 #. Translators: This is the explanation for the 'Monitor Switch Grace Period' under the 'Other' preference group in the 'General' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:490
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:502
 msgid ""
 "When a window is dragged to a new monitor the tile preview will stick to the "
 "old monitor for a very short time. This way you can tile windows by "
@@ -394,280 +406,280 @@ msgid ""
 msgstr ""
 
 #. Translators: This is a setting in the 'Other' preference group in the 'General' tab. If the user has performance issue when dragging windows around, this will improve it but will decrease the accuracy of the tiling previews
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:495
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:507
 msgid "Low Performance Movement Mode"
 msgstr ""
 
 #. Translators: This is the explanation for the 'Low Performance Movement Mode' under the 'Other' preference group in the 'General' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:496
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:508
 msgid ""
 "Use this if there is a lag when moving windows around. This will however "
 "decrease the precision of the tile preview updates."
 msgstr ""
 
 #. Translators: This is a setting in the 'Other' preference group in the 'General' tab. With this setting enabled, dragging windows to the screen edges won't use the default half-screen tiles but the tiles from the favorite layout
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:505
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:517
 msgid "Adapt 'Edge Tiling' to your Favorite Layout"
 msgstr ""
 
 #. Translators: This is a setting in the 'Other' preference group in the 'General' tab. This will set the modifier to activate the move mode 'Adaptive Tiling'
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:514
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:526
 msgid "'Adaptive Tiling' Move Mode Activator"
 msgstr ""
 
 #. Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:523
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:543
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:563
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:535
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:555
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:575
 msgid "Ctrl"
 msgstr ""
 
 #. Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:524
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:544
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:564
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:536
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:556
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:576
 msgid "Alt"
 msgstr ""
 
 #. Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab. RMB refers to the right mouse button
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:525
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:545
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:565
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:537
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:557
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:577
 msgid "RMB"
 msgstr ""
 
 #. Translators: This is a modifier for 'Adaptive Tiling Move Mode Activator' in the 'Other' preference group in the 'General' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:526
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:546
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:566
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:538
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:558
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:578
 msgid "Super"
 msgstr ""
 
 #. Translators: This is a setting in the 'Other' preference group in the 'General' tab. This will set the modifier to activate the move mode 'Favorite Layout'
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:534
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:546
 msgid "'Favorite Layout' Move Mode Activator"
 msgstr ""
 
 #. Translators: This is a setting in the 'Other' preference group in the 'General' tab. This will set the modifier to activate the move mode 'Ignore Tiling Assistant'
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:554
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:566
 msgid "'Ignore Tiling Assistant' Mode Activator"
 msgstr ""
 
 #. Translators: This is a setting in the 'Other' preference group in the 'General' tab. This is the area (in pixels) around the screen edges on the vertical axis that activates the tile previews
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:574
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:586
 msgid "Vertical Edge Preview Trigger Area"
 msgstr ""
 
 #. Translators: This is a setting in the 'Other' preference group in the 'General' tab. This is the area (in pixels) around the screen edges on the horizontal axis that activates the tile previews
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:592
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:604
 msgid "Horizontal Edge Preview Trigger Area"
 msgstr ""
 
 #. Translators: This is a setting in the 'Other' preference group in the 'General' tab. By default, when using 'Edge Tiling' and dragging the window to the top screen edge, the maximize tiling preview will show up. After some time the preview will switch to the top-half-screen tiling preview. This setting determines the duration of that timer
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:610
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:622
 msgid "Inverse Top Screen Edge Action Timer"
 msgstr ""
 
 #. Translators: This is a setting in the 'Other' preference group in the 'General' tab. By default, when using 'Edge Tiling' and dragging the window to the top screen edge, the maximize tiling preview will show up. After some time the preview will switch to the top-half-screen tiling preview. This setting makes the top-half-screen tiling preview before the maxmize preview on landscape displays
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:628
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:640
 msgid "Inverse Top Screen Edge Action for Landscape Displays"
 msgstr ""
 
 #. Translators: This is a setting in the 'Other' preference group in the 'General' tab. By default, when using 'Edge Tiling' and dragging the window to the top screen edge, the maximize tiling preview will show up. After some time the preview will switch to the top-half-screen tiling preview. This setting makes the top-half-screen tiling preview before the maxmize preview on portrait displays
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:637
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:649
 msgid "Inverse Top Screen Edge Action for Portrait Displays"
 msgstr ""
 
 #. Translators: This is the name of a tab in the prefs window
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:652
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:664
 msgid "Keybindings"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab that enables/disables the appearance of the Tiling Popup after a window is tiled
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:662
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:674
 msgid "Toggle 'Tiling Popup'"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab that activates the 'Tile Editing Mode'
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:667
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:679
 msgid "Tile Editing Mode"
 msgstr ""
 
 #. Translators: This is the explanation for the keybinding 'Tile Editing Mode' in the 'General' preference group in the 'Keybindings' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:668
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:680
 msgid "A keyboard-driven mode to manage your tiled windows"
 msgstr ""
 
 #. Translators: This is a (deprecated) keybinding in the 'General' preference group in the 'Keybindings' tab. Its name is a bit misleading. The keybinding will only tile 1 window. Its behavior depends on the current tiling layout. It may cause a window to fill the main empty space or untile a window
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:673
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:685
 msgid "Auto-Tile"
 msgstr ""
 
 #. Translators: This is the explanation for the keybinding 'Auto-Tile' in the 'General' preference group in the 'Keybindings' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:674
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:686
 msgid "Un/tile the current window based on the visible tiles"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:679
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:691
 msgid "Toggle 'Always on Top'"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:688
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:700
 msgid "Toggle Maximization"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:693
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:705
 msgid "Toggle Vertical Maximization"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:702
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:714
 msgid "Toggle Horizontal Maximization"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:711
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:723
 msgid "Restore Window Size"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'General' preference group in the 'Keybindings' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:716
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:728
 msgid "Move Window to Center"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'Edge Tiling' preference group in the 'Keybindings' tab to tile window to the top screen half
 #. Translators: This is a keybinding in the 'Edge Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the top screen half without spawning a Tiling Popup
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:729
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:789
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:741
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:801
 msgid "Tile to top"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'Edge Tiling' preference group in the 'Keybindings' tab to tile window to the bottom screen half
 #. Translators: This is a keybinding in the 'Edge Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the bottom screen half without spawning a Tiling Popup
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:734
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:794
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:746
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:806
 msgid "Tile to bottom"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'Edge Tiling' preference group in the 'Keybindings' tab to tile window to the left screen half
 #. Translators: This is a keybinding in the 'Edge Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the left screen half without spawning a Tiling Popup
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:739
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:799
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:751
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:811
 msgid "Tile to left"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'Edge Tiling' preference group in the 'Keybindings' tab to tile window to the right screen half
 #. Translators: This is a keybinding in the 'Edge Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the right screen half without spawning a Tiling Popup
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:744
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:804
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:756
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:816
 msgid "Tile to right"
 msgstr ""
 
 #. Translators: This is a header for a preference group in the 'Keybindings' tab to tile windows to quarters
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:754
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:766
 msgid "Corner Tiling"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'Corner Tiling' preference group in the 'Keybindings' tab to tile window to the top left quarter
 #. Translators: This is a keybinding in the 'Corner Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the top left quarter without spawning a Tiling Popup
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:757
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:821
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:769
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:833
 msgid "Tile to top-left"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'Corner Tiling' preference group in the 'Keybindings' tab to tile window to the top right quarter
 #. Translators: This is a keybinding in the 'Corner Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the top right quarter without spawning a Tiling Popup
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:762
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:826
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:774
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:838
 msgid "Tile to top-right"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'Corner Tiling' preference group in the 'Keybindings' tab to tile window to the bottom left quarter
 #. Translators: This is a keybinding in the 'Corner Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the bottom left quarter without spawning a Tiling Popup
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:767
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:831
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:779
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:843
 msgid "Tile to bottom-left"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'Corner Tiling' preference group in the 'Keybindings' tab to tile window to the bottom right quarter
 #. Translators: This is a keybinding in the 'Corner Tiling without Tiling Assistant' preference group in the 'Keybindings' tab to tile window to the bottom right quarter without spawning a Tiling Popup
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:772
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:836
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:784
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:848
 msgid "Tile to bottom-right"
 msgstr ""
 
 #. Translators: This is a header for a preference group in the 'Keybindings' tab to tile windows to screen halves without spawning a Tiling Popup
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:782
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:794
 msgid "Edge Tiling without Tiling Assistant"
 msgstr ""
 
 #. Translators: This is a header for a preference group in the 'Keybindings' tab to tile windows to quarters without spawning a Tiling Popup
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:814
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:826
 msgid "Corner Tiling without Tiling Assistant"
 msgstr ""
 
 #. Translators: This is a header for a preference group in the 'Keybindings' tab for some keybindings for debugging
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:846
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:858
 msgid "Debugging"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'Debugging' preference group in the 'Keybindings' tab to visibly show the tiled windows rectangles
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:853
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:865
 msgid "Show Tiled Rects"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'Debugging' preference group in the 'Keybindings' tab to visibly show the area of the tiles without windows
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:858
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:870
 msgid "Show Free Screen Rects"
 msgstr ""
 
 #. Translators: This is the name of a tab in the prefs window to configure tiling presets ('Layouts')
 #. Translators: This is a header for a preference group in the 'Layouts' tab where user can define layouts (tiling presets)
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:869
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:899
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:881
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:911
 msgid "Layouts"
 msgstr ""
 
 #. Translators: This is a setting in the 'General' preference group in the 'Layouts' tab to enable an icon in the top panel with some settings for the layouts
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:883
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:895
 msgid "Panel Indicator"
 msgstr ""
 
 #. Translators: This is a keybinding in the 'General' preference group in the 'Layouts' tab to show a popup with a list of the defined layouts
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:888
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:900
 msgid "Search for a Layout"
 msgstr ""
 
 #. Translators: This is the explanation for the keybinding 'Search for a Layout' in the 'General' preference group in the 'Layouts' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:889
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:901
 msgid "Open a popup listing all the available layouts"
 msgstr ""
 
 #. Translators: This is a tooltip for a button that defines a new tiling preset (layout) in the 'Layouts' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:923
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:935
 msgid "Add a new Layout."
 msgstr ""
 
 #. Translators: This is a tooltip for a button that saves the changes to the defined tiling presets (layouts) in the 'Layouts' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:930
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:942
 msgid "Save the layouts to the disk. Invalid changes will be lost!"
 msgstr ""
 
 #. Translators: This is a tooltip for a button that reloads the the layouts from the disks in the 'Layouts' tab
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:937
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:949
 msgid "Reload the layouts from the disk - discarding all non-saved changes."
 msgstr ""
 
 #. Translators: This is the setting to toggle the visibility of advanced/experimental settings in the preference window that can be enabled via the headerbar popup menu
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:994
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:1006
 msgid "Advanced / Experimental Settings"
 msgstr ""
 
 #. Translators: This is the explanation for the 'Advanced / Experimental Settings' setting in the preference window that can be enabled via the headerbar popup menu
-#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:995
+#: tiling-assistant@leleat-on-github/src/ui/prefs.ui:1007
 msgid "Show more settings in the main preference window"
 msgstr ""
 
@@ -682,12 +694,12 @@ msgid "Clear the keyboard shortcuts"
 msgstr ""
 
 #. Translators: This is the notification text when the Tiling Popup is enabled/disabled via the keyboard shortcut
-#: tiling-assistant@leleat-on-github/src/extension/keybindingHandler.js:57
+#: tiling-assistant@leleat-on-github/src/extension/keybindingHandler.js:62
 msgid "Tiling popup enabled"
 msgstr ""
 
 #. Translators: This is the notification text when the Tiling Popup is enabled/disabled via the keyboard shortcut
-#: tiling-assistant@leleat-on-github/src/extension/keybindingHandler.js:59
+#: tiling-assistant@leleat-on-github/src/extension/keybindingHandler.js:64
 msgid "Tiling popup was disabled"
 msgstr ""
 


### PR DESCRIPTION
## Summary

- Add an opt-in `Edge Cycle` dynamic keybinding behavior.
- Cycle full-height edge tiles through equal half, third, and quarter widths.
- Keep existing dynamic keybinding modes and defaults unchanged.
- Add pure geometry tests, preferences UI text, documentation, and an `npm test` CI step.

## Behavior

With **Preferences → General → Dynamic Keybinding Behavior → Edge Cycle** enabled:

```text
Super+Left:  left half -> left third -> left quarter -> left half
Super+Right: right half -> right third -> right quarter -> right half
```

If the active window is not already at the requested edge in a recognized full-height state, the first press selects the corresponding half-width tile. Pressing the opposite direction starts the opposite edge at half width. The current intended `tiledRect` is used for state detection so configured Tiling Assistant gaps do not break the cycle.

No default GNOME shortcut is changed. Users who want vertical-only behavior for `Super+Up` can assign the existing `tile-maximize-vertically` action manually after clearing the normal `tile-maximize` binding.

## Implementation

- Add `DynamicKeybindings.EDGE_CYCLE` as a new settings mode.
- Add a dependency-free `edgeCycle.js` helper for:
  - division cycling and wraparound;
  - left/right edge rectangle generation;
  - full-height tile detection with a small coordinate tolerance.
- Reuse `Rect` and `TilingWindowManager.tile()` for Wayland-native window movement, gap handling, restore/unmaximize behavior, and tile state management.
- Add the mode to the existing radio-button preferences and translation template.
- Keep the default GSettings value at `0` (Disabled).

## Validation

- `npm test` — 6 tests passed.
- ESLint on all changed JavaScript files — passed.
- `git diff --check` — passed.
- GSettings schema compilation and XML well-formedness — passed.
- `scripts/build.sh` — passed; extension package generated.
- GJS smoke test importing the new helper — passed.

The built extension was installed into the user extension directory. The current Wayland GNOME Shell session still reports the pre-existing system copy as active; a GNOME Shell/session restart is required before exercising the new keybindings interactively.

## Review focus

- Confirm whether `Edge Cycle` should remain part of the existing dynamic-keybinding mode selector or become a separate setting.
- Confirm the intended default cycle order and whether future custom division lists should be exposed in preferences.
- Validate behavior with multiple monitors, configured gaps, manually resized windows, non-resizable windows, and existing tile groups.
